### PR TITLE
adding node::Queue; refactoring SinkChannel for code reuse

### DIFF
--- a/include/srf/node/edge_builder.hpp
+++ b/include/srf/node/edge_builder.hpp
@@ -19,6 +19,7 @@
 
 #include <srf/channel/ingress.hpp>
 #include <srf/node/edge.hpp>
+#include <srf/node/edge_properties.hpp>
 #include <srf/node/sink_properties.hpp>
 #include <srf/node/source_properties.hpp>
 #include <srf/utils/type_utils.hpp>
@@ -73,6 +74,12 @@ struct EdgeBuilder final
         source.complete_edge(edge);
     }
 
+    template <typename T>
+    static void make_edge(ChannelProvider<T>& source, ChannelAcceptor<T>& sink)
+    {
+        sink.set_channel(source.channel());
+    }
+
     static void make_edge_typeless(SourceTypeErased& source, SinkTypeErased& sink, bool allow_narrowing = true)
     {
         source.complete_edge(source.ingress_adaptor_for_sink(sink));
@@ -81,6 +88,12 @@ struct EdgeBuilder final
 
 template <typename SourceT, typename SinkT = SourceT>
 void make_edge(SourceProperties<SourceT>& source, SinkProperties<SinkT>& sink)
+{
+    EdgeBuilder::make_edge(source, sink);
+}
+
+template <typename SourceT, typename SinkT = SourceT>
+void make_edge(ChannelProvider<SourceT>& source, ChannelAcceptor<SinkT>& sink)
 {
     EdgeBuilder::make_edge(source, sink);
 }

--- a/include/srf/node/edge_properties.hpp
+++ b/include/srf/node/edge_properties.hpp
@@ -1,0 +1,64 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <srf/channel/channel.hpp>
+#include <srf/channel/ingress.hpp>
+
+#include <memory>
+
+namespace srf::node {
+
+// If:
+// - SourceChannel<T> is an IngressAcceptor
+// - SinkChannel<T> can be either an IngressProvider or a ChannelAcceptor
+// - Queue<T> is an IngressProivder and a ChannelProvider
+
+// Then, Edges can be from:
+// - make_edge(IngressAcceptor<T>, IngressProivder<T>)
+// - make_edge(ChannelProvider<T>, ChannelAcceptor<T>)
+
+// Queue<T> is not an IngressAcceptor<T> nor ChannelAcceptor<T>, therefore, edges cannot be formed between Queues
+// - this is a good thing, a Queue is simply a Channel holder with no progress engine, thus unable to driver forward
+// progress.
+
+class EdgeBuilder;
+
+template <typename T>
+class ChannelProvider
+{
+  public:
+    virtual ~ChannelProvider() = default;
+
+  private:
+    virtual std::shared_ptr<channel::Channel<T>> channel() = 0;
+    friend EdgeBuilder;
+};
+
+template <typename T>
+class ChannelAcceptor
+{
+  public:
+    virtual ~ChannelAcceptor() = default;
+
+  private:
+    virtual void set_channel(std::shared_ptr<channel::Channel<T>> channel) = 0;
+    friend EdgeBuilder;
+};
+
+}  // namespace srf::node

--- a/include/srf/node/queue.hpp
+++ b/include/srf/node/queue.hpp
@@ -1,0 +1,48 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "srf/channel/ingress.hpp"
+#include "srf/node/edge_properties.hpp"
+#include "srf/node/forward.hpp"
+#include "srf/node/sink_channel_base.hpp"
+
+namespace srf::node {
+
+template <typename T>
+class Queue final : public SinkChannelBase<T>, public SinkProperties<T>, public ChannelProvider<T>
+{
+  public:
+    Queue()        = default;
+    ~Queue() final = default;
+
+  private:
+    // SinkProperties<T> - aka IngressProvider
+    std::shared_ptr<channel::Ingress<T>> channel_ingress() final
+    {
+        return SinkChannelBase<T>::ingress_channel();
+    }
+
+    // ChannelProvider
+    std::shared_ptr<channel::Channel<T>> channel() final
+    {
+        return SinkChannelBase<T>::channel();
+    }
+};
+
+}  // namespace srf::node

--- a/include/srf/node/sink_channel_base.hpp
+++ b/include/srf/node/sink_channel_base.hpp
@@ -1,0 +1,237 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <srf/channel/buffered_channel.hpp>
+#include <srf/channel/ingress.hpp>
+#include <srf/constants.hpp>
+#include <srf/exceptions/runtime_error.hpp>
+#include <srf/node/edge.hpp>
+#include <srf/node/edge_properties.hpp>
+#include <srf/node/forward.hpp>
+#include <srf/node/sink_properties.hpp>
+#include <srf/utils/type_utils.hpp>
+#include "srf/channel/egress.hpp"
+
+#include <mutex>
+
+namespace srf::node {
+
+/**
+ * @brief Extends SinkProperties to hold a Channel and provide SinkProperties access the the channel ingress
+ *
+ * @tparam T
+ */
+template <typename T>
+class SinkChannelBase
+{
+  protected:
+    SinkChannelBase();
+
+  public:
+    /**
+     * @brief Enables persistence of the Channel.
+     *
+     * The default behavior is to close the owned Channel after all Ingress objects created from channel_ingress have
+     * been destroyed. The persistent option keeps an internal Ingress object live preventing channel closure.
+     *
+     * Invoking stop on the Runner which owns the Runnable explicitly disables persistence.
+     */
+    void enable_persistence();
+
+    /**
+     * @brief Disables persistence of the Channel
+     */
+    void disable_persistence();
+
+    /**
+     * @brief Determine if the Channel is persistent or not.
+     *
+     * @return true
+     * @return false
+     */
+    bool is_persistent() const;
+
+    /**
+     * @brief Replace the current Channel.
+     *
+     * An update can only occur if persistence has not be been requested and no external entities have acquired an
+     * Ingress.
+     *
+     * @param channel
+     */
+    void update_channel(std::unique_ptr<Channel<T>> channel);
+
+    /**
+     * @brief The number of outstanding edge connections from this SinkChannel to SourceChannels
+     *
+     * @return std::size_t
+     */
+    std::size_t use_count()
+    {
+        return m_ingress.use_count();
+    }
+
+  protected:
+    inline channel::Egress<T>& egress()
+    {
+        DCHECK(m_channel);
+        return *m_channel;
+    }
+
+    // access the full channel
+    std::shared_ptr<channel::Channel<T>> channel();
+
+    // alternative to update_channel
+    // disables ingress_channel
+    void set_shared_channel(std::shared_ptr<channel::Channel<T>> channel);
+
+    // thread safe access to
+    [[nodiscard]] std::shared_ptr<channel::Ingress<T>> ingress_channel();
+
+  private:
+    [[nodiscard]] std::shared_ptr<channel::Ingress<T>> ingress_channel_unsafe();
+
+    // holds the original channel passed into the constructor or set via update_channel
+    std::shared_ptr<Channel<T>> m_channel;
+
+    // holder for the specialized ingress
+    std::weak_ptr<Edge<T>> m_ingress;
+
+    // used to make the channel reader persistent by explicitly holding shared_ptr created from calling weak_ptr::lock
+    std::shared_ptr<Edge<T>> m_persistent_ingress{nullptr};
+
+    // indicates whether or not a channel connection was ever made
+    bool m_ingress_initialized{false};
+
+    // indicates if the channel is a unique or shared channel
+    // an error will be thrown if attempting to call ingress_channel on a shared channel
+    bool m_unique_channel{true};
+
+    // recursive mutex to protect ingress creation; recursion required for persistence
+    mutable std::mutex m_mutex;
+};
+
+template <typename T>
+SinkChannelBase<T>::SinkChannelBase() : m_channel(std::make_unique<channel::BufferedChannel<T>>())
+{}
+
+template <typename T>
+std::shared_ptr<channel::Channel<T>> SinkChannelBase<T>::channel()
+{
+    std::lock_guard<decltype(m_mutex)> lock(m_mutex);
+    CHECK(m_channel);
+    return m_channel;
+}
+
+template <typename T>
+std::shared_ptr<channel::Ingress<T>> SinkChannelBase<T>::ingress_channel()
+{
+    std::lock_guard<decltype(m_mutex)> lock(m_mutex);
+    return ingress_channel_unsafe();
+}
+
+template <typename T>
+std::shared_ptr<channel::Ingress<T>> SinkChannelBase<T>::ingress_channel_unsafe()
+{
+    CHECK(m_channel);
+    CHECK(m_unique_channel);
+    std::shared_ptr<Edge<T>> ingress;
+
+    if (m_channel->is_channel_closed())
+    {
+        throw exceptions::SrfRuntimeError("attempting to acquire an Ingress to a closed channel");
+    }
+
+    // the last holder that owns a shared_ptr<Ingress> will close the channel
+    // when the final instance of the shared_ptr is either reset or goes out of scope
+    if ((ingress = m_ingress.lock()))
+    {
+        return ingress;
+    }
+
+    // make a copy of the shared_ptr to the Channel so we can capture it in the deleter
+    auto channel_holder = m_channel;
+
+    // create the first shared pointer of this input channel and capture the shared_ptr as part of the deleter
+    ingress = std::shared_ptr<Edge<T>>(new Edge<T>(m_channel), [channel_holder](Edge<T>* ptr) {
+        channel_holder->close_channel();
+        delete ptr;
+    });
+
+    // assign the weak_ptr
+    m_ingress             = ingress;
+    m_ingress_initialized = true;
+
+    return ingress;
+}
+
+template <typename T>
+void SinkChannelBase<T>::update_channel(std::unique_ptr<Channel<T>> channel)
+{
+    std::lock_guard<decltype(m_mutex)> lock(m_mutex);
+
+    CHECK(channel);
+    CHECK(!m_ingress_initialized);
+    CHECK_EQ(m_channel.use_count(), 1) << "can not modify the input channel after it has been shared or is persistent";
+    m_channel = std::move(channel);
+}
+
+template <typename T>
+void SinkChannelBase<T>::set_shared_channel(std::shared_ptr<Channel<T>> channel)
+{
+    std::lock_guard<decltype(m_mutex)> lock(m_mutex);
+
+    CHECK(channel);
+    CHECK(m_unique_channel);
+    CHECK(!m_ingress_initialized);
+    CHECK_EQ(m_channel.use_count(), 1) << "can not modify the input channel after it has been shared or is persistent";
+
+    m_channel        = std::move(channel);
+    m_unique_channel = false;
+}
+
+template <typename T>
+bool SinkChannelBase<T>::is_persistent() const
+{
+    std::lock_guard<decltype(m_mutex)> lock(m_mutex);
+    return (m_persistent_ingress != nullptr);
+}
+
+template <typename T>
+void SinkChannelBase<T>::disable_persistence()
+{
+    std::lock_guard<decltype(m_mutex)> lock(m_mutex);
+    m_persistent_ingress = nullptr;
+}
+
+template <typename T>
+void SinkChannelBase<T>::enable_persistence()
+{
+    std::lock_guard<decltype(m_mutex)> lock(m_mutex);
+    if (m_persistent_ingress)
+    {
+        return;
+    }
+    // Get and hold onto the input channel
+    auto persistent = ingress_channel_unsafe();
+    CHECK(persistent);
+    m_persistent_ingress = std::move(persistent);
+}
+
+}  // namespace srf::node

--- a/include/srf/segment/builder.hpp
+++ b/include/srf/segment/builder.hpp
@@ -28,6 +28,7 @@
 #include <srf/segment/egress_port.hpp>
 #include <srf/segment/forward.hpp>
 #include <srf/segment/object.hpp>
+#include <srf/segment/resource.hpp>
 #include <srf/segment/runnable.hpp>
 #include <srf/utils/macros.hpp>
 #include "srf/internal/segment/ibuilder.hpp"
@@ -206,9 +207,12 @@ std::shared_ptr<Object<ObjectT>> Builder::make_object(std::string name, std::uni
     }
     else
     {
-        LOG(FATAL) << "unable to create non-launchable segment object at this time";
+        auto segment_node = std::make_shared<Resource<ObjectT>>(std::move(node));
+        add_object(name, segment_node);
+        segment_object = segment_node;
     }
 
+    CHECK(segment_object);
     return segment_object;
 }
 

--- a/include/srf/segment/resource.hpp
+++ b/include/srf/segment/resource.hpp
@@ -1,0 +1,46 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <srf/segment/object.hpp>
+
+#include <glog/logging.h>
+
+#include <memory>
+#include <ostream>
+#include <utility>
+
+namespace srf::segment {
+
+template <typename ResourceT>
+class Resource final : public Object<ResourceT>
+{
+  public:
+    Resource(std::unique_ptr<ResourceT> resource) : m_resource(std::move(resource)) {}
+    ~Resource() final = default;
+
+  private:
+    ResourceT* get_object() const final
+    {
+        CHECK(m_resource);
+        return m_resource.get();
+    }
+    std::unique_ptr<ResourceT> m_resource;
+};
+
+}  // namespace srf::segment

--- a/src/tests/test_pipeline.cpp
+++ b/src/tests/test_pipeline.cpp
@@ -31,6 +31,7 @@
 #include "srf/core/executor.hpp"
 #include "srf/internal/pipeline/ipipeline.hpp"
 #include "srf/internal/segment/idefinition.hpp"
+#include "srf/node/queue.hpp"
 #include "srf/node/rx_sink.hpp"
 #include "srf/node/rx_source.hpp"
 #include "srf/node/sink_properties.hpp"
@@ -189,6 +190,21 @@ TEST_F(TestPipeline, LifeCycleStop)
         auto rx_source = s.make_object("rx_source", test::nodes::infinite_int_rx_source());
         auto rx_sink   = s.make_object("rx_sink", test::nodes::int_sink());
         s.make_edge(rx_source, rx_sink);
+    });
+
+    run_manager(std::move(pipeline), true);
+}
+
+TEST_F(TestPipeline, Queue)
+{
+    auto pipeline = srf::make_pipeline();
+
+    auto segment = pipeline->make_segment("seg_1", [](segment::Builder& s) {
+        auto source = s.make_object("source", test::nodes::infinite_int_rx_source());
+        auto queue  = s.make_object("queue", std::make_unique<node::Queue<int>>());
+        auto sink   = s.make_object("sink", test::nodes::int_sink());
+        s.make_edge(source, queue);
+        s.make_edge(queue, sink);
     });
 
     run_manager(std::move(pipeline), true);


### PR DESCRIPTION
In our original design, we had three entities required to form an edge: a Source, Channel and Sink.

This required constructing three object and making two calls to form an edge, pseudo code
```
auto source = s.make_source<T>(...);
auto channel = s.make_channel<T>(...);
auto sink = s.make_sink<T>(...);

s.make_edge(source, channel);
s.make_edge(channel, sink);
```

To reduce complexity for common patterns, it was decided that Sinks would own Channels and provide them to Sources. This had the effect of reducing complexity for edge construction to the creation of a source and a sink and the formation of an edge.

```
auto source = s.make_source<T>(...);
auto sink = s.make_sink<T>(...);

s.make_edge(source, sink);
```

While this reduction in complexity is nice, it also creates a limitation in that each Sink owns its own Channel. This makes load-balancing work across multiple downstream Sinks more difficult, because work is being pushed to each Sink. Pushing has several problems:

- Any write to a Sink's channel which is full, fiber yields the writer.
  - This means if we have N Sinks to which we want to write, we need to have a unique writer per Sink or risk stalling a single writer by blocking on write.
- Sinks operating at different speeds, either from heterogeneous hardware or by the fact the operation being performed may have variable length wall time based on inputs, means push based load-balancing will be problematic.

This MR adds the ability for pull based Sinks using a design similar to the original allowing for standalone `Queue` (Channel holder), but with the default being the current behavior.

```
// Let:
// - SourceProperties<T> be an IngressAcceptor
// - SinkProperties<T> be an IngressProvider

// If:
// - SourceChannel<T> is an IngressAcceptor
// - SinkChannel<T> can be either an IngressProvider or a ChannelAcceptor
// - Queue<T> is an IngressProivder and a ChannelProvider

// Then, Edges can be from:
// - make_edge(IngressAcceptor<T>, IngressProivder<T>)
// - make_edge(ChannelProvider<T>, ChannelAcceptor<T>)
```

This enabled the following example's Sink to be a pull based Sink:

```
        auto source = s.make_object("source", test::nodes::infinite_int_rx_source());
        auto queue  = s.make_object("queue", std::make_unique<node::Queue<int>>());
        auto sink   = s.make_object("sink", test::nodes::int_sink());
        s.make_edge(source, queue);
        s.make_edge(queue, sink);
```

There is no change to the API or default behavior of node/segment objects.