### PR TITLE
adding PortGraph; validate Pipeline definitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,8 +192,9 @@ add_library(libsrf
   src/internal/executor/iexecutor.cpp
   src/internal/pipeline/controller.cpp
   src/internal/pipeline/instance.cpp
-  src/internal/pipeline/pipeline.cpp
   src/internal/pipeline/ipipeline.cpp
+  src/internal/pipeline/pipeline.cpp
+  src/internal/pipeline/port_graph.cpp
   src/internal/pipeline/manager.cpp
   src/internal/pipeline/resources.cpp
   src/internal/resources/device_resources.cpp

--- a/src/internal/executor/executor.cpp
+++ b/src/internal/executor/executor.cpp
@@ -19,10 +19,13 @@
 
 #include "internal/pipeline/manager.hpp"
 #include "internal/pipeline/pipeline.hpp"
+#include "internal/pipeline/port_graph.hpp"
 #include "internal/pipeline/types.hpp"
 #include "internal/resources/resource_partitions.hpp"
 #include "internal/system/system.hpp"
+#include "internal/utils/contains.hpp"
 #include "srf/core/addresses.hpp"
+#include "srf/exceptions/runtime_error.hpp"
 #include "srf/internal/pipeline/ipipeline.hpp"
 #include "srf/options/options.hpp"
 #include "srf/types.hpp"
@@ -32,6 +35,8 @@
 #include <map>
 
 namespace srf::internal::executor {
+
+static bool valid_pipeline(const pipeline::Pipeline& pipeline);
 
 Executor::Executor(Handle<Options> options) :
   m_system(system::make_system(std::move(options))),
@@ -53,7 +58,13 @@ void Executor::register_pipeline(std::unique_ptr<pipeline::IPipeline> ipipeline)
     CHECK(ipipeline);
     CHECK(m_pipeline_manager == nullptr);
 
-    auto pipeline      = pipeline::Pipeline::unwrap(*ipipeline);
+    auto pipeline = pipeline::Pipeline::unwrap(*ipipeline);
+
+    if (!valid_pipeline(*pipeline))
+    {
+        throw exceptions::SrfRuntimeError("pipeline validation failed");
+    }
+
     m_pipeline_manager = std::make_unique<pipeline::Manager>(pipeline, m_resources);
 
     pipeline::SegmentAddresses initial_segments;
@@ -89,6 +100,43 @@ void Executor::do_service_await_join()
 {
     CHECK(m_pipeline_manager);
     m_pipeline_manager->service_await_join();
+}
+
+// convert to std::expect
+bool valid_pipeline(const pipeline::Pipeline& pipeline)
+{
+    bool valid = true;
+    pipeline::PortGraph pg(pipeline);
+
+    for (const auto& [name, connections] : pg.port_map())
+    {
+        // first validate all port names have at least one:
+        // - segment using that port as an ingress, and
+        // - segment using that port as an egress
+        if (connections.egress_segments.empty() or connections.ingress_segments.empty())
+        {
+            valid = false;
+            // todo - print list of segments names for ingress/egres connections to this port
+            LOG(WARNING) << "port: " << name << " has incomplete connections - used as ingress on "
+                         << connections.ingress_segments.size() << " segments; used as egress on "
+                         << connections.egress_segments.size() << " segments";
+        }
+
+        // we currently only have an load-balancer manifold
+        // it doesn't make sense to connect segments of different types to a load-balancer, they should probably be
+        // broadcast
+        // in general, if there are more than one type of segments writing to or reading from a manifold, then that port
+        // should have an explicit manifold type specified
+        if (connections.egress_segments.size() > 1 or connections.ingress_segments.size() > 1)
+        {
+            valid = false;
+            LOG(WARNING) << "port: " << name
+                         << " has more than 1 segment type connected to an ingress or egress port; this is currently "
+                            "an invalid configuration as there are no manifold available to handle this condition";
+        }
+    }
+
+    return valid;
 }
 
 }  // namespace srf::internal::executor

--- a/src/internal/pipeline/port_graph.cpp
+++ b/src/internal/pipeline/port_graph.cpp
@@ -1,0 +1,72 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "internal/pipeline/port_graph.hpp"
+
+#include "internal/pipeline/pipeline.hpp"
+#include "internal/segment/definition.hpp"
+
+namespace srf::internal::pipeline {
+
+PortGraph::PortGraph(const Pipeline& pipeline)
+{
+    for (const auto& [seg_id, seg_definition] : pipeline.segments())
+    {
+        auto seg_name = seg_definition->name();
+
+        if (seg_definition->ingress_port_names().empty() and seg_definition->egress_port_names().empty())
+        {
+            m_standalone.insert(seg_name);
+        }
+        else if (seg_definition->ingress_port_names().empty())
+        {
+            m_sources.insert(seg_name);
+        }
+        else if (seg_definition->egress_port_names().empty())
+        {
+            m_sinks.insert(seg_name);
+        }
+
+        for (const auto& name : seg_definition->ingress_port_names())
+        {
+            m_port_map[name].ingress_segments.insert(seg_name);
+        }
+
+        for (const auto& name : seg_definition->egress_port_names())
+        {
+            m_port_map[name].egress_segments.insert(seg_name);
+        }
+    }
+}
+
+const PortMap& PortGraph::port_map() const
+{
+    return m_port_map;
+}
+const std::set<std::string>& PortGraph::segments_with_no_ports() const
+{
+    return m_standalone;
+}
+const std::set<std::string>& PortGraph::segments_with_only_ingress_ports() const
+{
+    return m_sources;
+}
+const std::set<std::string>& PortGraph::segments_with_only_egress_ports() const
+{
+    return m_sinks;
+}
+}  // namespace srf::internal::pipeline

--- a/src/internal/pipeline/port_graph.hpp
+++ b/src/internal/pipeline/port_graph.hpp
@@ -1,0 +1,65 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <map>
+#include <set>
+#include <string>
+
+/**
+ * @brief Graph of Pipeline Ports
+ */
+
+namespace srf::internal::pipeline {
+
+class Pipeline;
+
+struct PortConnections
+{
+    // set of segments that have ingress ports
+    std::set<std::string> ingress_segments;
+    std::set<std::string> egress_segments;
+};
+
+using PortMap = std::map<std::string, PortConnections>;  // NOLINT
+
+class PortGraph
+{
+  public:
+    PortGraph(const Pipeline& pipeline);
+
+    const PortMap& port_map() const;
+
+    const std::set<std::string>& segments_with_no_ports() const;
+    const std::set<std::string>& segments_with_only_ingress_ports() const;
+    const std::set<std::string>& segments_with_only_egress_ports() const;
+
+  private:
+    PortMap m_port_map;
+
+    // segments with no ports
+    std::set<std::string> m_standalone;
+
+    // segments with only ingress ports
+    std::set<std::string> m_sinks;
+
+    // segments with only egress ports
+    std::set<std::string> m_sources;
+};
+
+}  // namespace srf::internal::pipeline

--- a/src/tests/test_pipeline.cpp
+++ b/src/tests/test_pipeline.cpp
@@ -279,3 +279,56 @@ TEST_F(TestPipeline, MultiSegmentLoadBalancer)
     EXPECT_EQ(ranks.size(), count);
     EXPECT_EQ(count_by_rank.size(), 2);
 }
+
+TEST_F(TestPipeline, UnmatchedIngress)
+{
+    std::function<void(srf::segment::Builder&)> init = [](srf::segment::Builder& builder) {};
+
+    auto pipe = pipeline::make_pipeline();
+
+    pipe->make_segment("TestSegment1", segment::IngressPorts<int>({"some_port"}), init);
+
+    auto opt1 = std::make_shared<srf::Options>();
+    opt1->topology().user_cpuset("0");
+    opt1->topology().restrict_gpus(true);
+
+    srf::Executor exec1{opt1};
+
+    EXPECT_ANY_THROW(exec1.register_pipeline(std::move(pipe)));
+}
+
+TEST_F(TestPipeline, UnmatchedEgress)
+{
+    std::function<void(srf::segment::Builder&)> init = [](srf::segment::Builder& builder) {};
+
+    auto pipe = pipeline::make_pipeline();
+
+    pipe->make_segment("TestSegment1", segment::EgressPorts<int>({"some_port"}), init);
+
+    auto opt1 = std::make_shared<srf::Options>();
+    opt1->topology().user_cpuset("0");
+    opt1->topology().restrict_gpus(true);
+
+    srf::Executor exec1{opt1};
+
+    EXPECT_ANY_THROW(exec1.register_pipeline(std::move(pipe)));
+}
+
+TEST_F(TestPipeline, RequiresMoreManifolds)
+{
+    std::function<void(srf::segment::Builder&)> init = [](srf::segment::Builder& builder) {};
+
+    auto pipe = pipeline::make_pipeline();
+
+    pipe->make_segment("TestSegment1", segment::EgressPorts<int>({"some_port"}), init);
+    pipe->make_segment("TestSegment2", segment::IngressPorts<int>({"some_port"}), init);
+    pipe->make_segment("TestSegment3", segment::IngressPorts<int>({"some_port"}), init);
+
+    auto opt1 = std::make_shared<srf::Options>();
+    opt1->topology().user_cpuset("0");
+    opt1->topology().restrict_gpus(true);
+
+    srf::Executor exec1{opt1};
+
+    EXPECT_ANY_THROW(exec1.register_pipeline(std::move(pipe)));
+}


### PR DESCRIPTION
Fixes #27 by throwing an exception when registering a pipeline with an incomplete or currently invalid port configuration.