### PR TITLE
Improve error handling on pipeline::Controller updates

### DIFF
--- a/src/internal/pipeline/controller.cpp
+++ b/src/internal/pipeline/controller.cpp
@@ -33,6 +33,7 @@
 #include <glog/logging.h>
 
 #include <algorithm>
+#include <exception>
 #include <iterator>
 #include <map>
 #include <memory>
@@ -57,7 +58,15 @@ void Controller::on_data(ControlMessage&& message)
     switch (message.type)
     {
     case ControlMessageType::Update:
-        update(std::move(message.addresses));
+        try
+        {
+            update(std::move(message.addresses));
+        } catch (...)
+        {
+            LOG(ERROR) << "exception caught while performing update - this is fatal - issuing kill";
+            kill();
+            std::rethrow_exception(std::current_exception());
+        }
         break;
     case ControlMessageType::Stop:
         stop();

--- a/src/tests/test_pipeline.cpp
+++ b/src/tests/test_pipeline.cpp
@@ -63,6 +63,7 @@
 #include <memory>
 #include <mutex>
 #include <ostream>
+#include <stdexcept>
 #include <string>
 #include <system_error>
 #include <thread>
@@ -192,6 +193,13 @@ TEST_F(TestPipeline, LifeCycleStop)
     });
 
     run_manager(std::move(pipeline), true);
+}
+
+TEST_F(TestPipeline, InitializerThrows)
+{
+    auto pipeline = srf::make_pipeline();
+    auto segment  = pipeline->make_segment("seg_1", [](segment::Builder& s) { throw std::runtime_error("no bueno"); });
+    EXPECT_ANY_THROW(run_manager(std::move(pipeline)));
 }
 
 TEST_F(TestPipeline, DuplicateNameInSegment)


### PR DESCRIPTION
Fixes #26 by improving error handling on the `pipeline::Controller` update method