### PR TITLE
Explicitly Specify Version for `rapids_export`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -329,7 +329,7 @@ set(rapids_project_version_compat SameMinorVersion)
 rapids_export(INSTALL ${PROJECT_NAME}
   EXPORT_SET ${PROJECT_NAME}-core-exports
   GLOBAL_TARGETS libsrf
-  VERSION
+  VERSION 22.06.00
   NAMESPACE srf::
   DOCUMENTATION doc_string
   FINAL_CODE_BLOCK code_string
@@ -341,7 +341,7 @@ rapids_export(INSTALL ${PROJECT_NAME}
 rapids_export(BUILD ${PROJECT_NAME}
   EXPORT_SET ${PROJECT_NAME}-core-exports
   GLOBAL_TARGETS libsrf
-  VERSION
+  VERSION 22.06.00
   LANGUAGES C CXX CUDA
   NAMESPACE srf::
   DOCUMENTATION doc_string

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -326,10 +326,12 @@ set(code_string "")
 
 set(rapids_project_version_compat SameMinorVersion)
 
+# Need to explicitly set VERSION ${PROJECT_VERSION} here since rapids_cmake gets
+# confused with the `RAPIDS_VERSION` variable we use
 rapids_export(INSTALL ${PROJECT_NAME}
   EXPORT_SET ${PROJECT_NAME}-core-exports
   GLOBAL_TARGETS libsrf
-  VERSION 22.06.00
+  VERSION ${PROJECT_VERSION}
   NAMESPACE srf::
   DOCUMENTATION doc_string
   FINAL_CODE_BLOCK code_string
@@ -341,7 +343,7 @@ rapids_export(INSTALL ${PROJECT_NAME}
 rapids_export(BUILD ${PROJECT_NAME}
   EXPORT_SET ${PROJECT_NAME}-core-exports
   GLOBAL_TARGETS libsrf
-  VERSION 22.06.00
+  VERSION ${PROJECT_VERSION}
   LANGUAGES C CXX CUDA
   NAMESPACE srf::
   DOCUMENTATION doc_string


### PR DESCRIPTION
The function `rapids_export` uses the variable `RAPIDS_VERSION` to determine the version to export. Since we also have this defined as a cache entry, the function incorrectly exports `RAPIDS_VERSION` in the CMake config file, not `PROJECT_VERSION` as it should according to the docs. This breaks any dependencies that use the SRF conda package.