### PR TITLE
[gpuCI] Forward-merge branch-22.06 to branch-22.08 [skip gpuci]

### DIFF
--- a/ci/conda/environments/dev_env.yml
+++ b/ci/conda/environments/dev_env.yml
@@ -31,6 +31,7 @@ dependencies:
   - numpy=1.21.2
   - nvcc_linux-64=11.4
   - pkg-config=0.29
+  - pybind11-stubgen=0.10
   - python=3.8
   - scikit-build>=0.12
   - spdlog=1.8.5
@@ -41,7 +42,6 @@ dependencies:
     - flake8
     - isort
     - numpy==1.21.2
-    - pybind11-stubgen==0.10.5
     - pytest
     - pytest-timeout
     - yapf

--- a/ci/conda/recipes/libsrf/meta.yaml
+++ b/ci/conda/recipes/libsrf/meta.yaml
@@ -67,6 +67,7 @@ requirements:
     - librmm {{ rapids_version }}
     - nlohmann_json 3.9.1
     - pybind11-abi # See: https://conda-forge.org/docs/maintainer/knowledge_base.html#pybind11-abi-constraints
+    - pybind11-stubgen 0.10
     - python {{ python }}
     - scikit-build >=0.12
     - spdlog 1.8.5


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.06` that creates a PR to keep `branch-22.08` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.