### PR TITLE
Refresh and Simplification of QSG README

### DIFF
--- a/docs/quickstart/README.md
+++ b/docs/quickstart/README.md
@@ -1,39 +1,83 @@
+<!-- omit in toc -->
 # SRF Quick Start Guide
-:surfer: Learn to SRF and Catch the Wave to Accelerating Streaming Pipelines :surfer:
+:surfer: **Learn to SRF and Catch the Wave to GPU-Accelerated Streaming Pipelines** :surfer:
 
-The SRF Quick Start Guide (QSG) provides examples on how to get started using SRF. The goal of this tutorial is to provide a gentle on-ramp to building applications with SRF and is targeted towards a wide person of developers - ranging from data scientists to performance engineers.
+The SRF Quick Start Guide (QSG) provides Python, C++, and Hybrid (Python and C++) examples on how to get started building high-performance streaming pipelines with the SRF library. The goal of this tutorial is to provide a gentle on-ramp to building applications with SRF and is targeted towards a wide persona of developers - ranging from data scientists to performance engineers.
 
+<!-- omit in toc -->
 ## Table of Contents
+- [Environment Setup](#environment-setup)
+  - [Installing Examples via Conda](#installing-examples-via-conda)
+  - [Installing Examples via Source](#installing-examples-via-source)
+- [Python SRF Examples](#python-srf-examples)
+  - [Running the Examples](#running-the-examples)
+- [C++ SRF Examples](#c-srf-examples)
+  - [Setup](#setup)
+  - [Running the Examples](#running-the-examples-1)
+- [Hybrid (Python and C++) SRF Examples](#hybrid-python-and-c-srf-examples)
+  - [Setup](#setup-1)
+  - [Running the Examples](#running-the-examples-2)
 
-## Getting Started
 
-To get started with the QSG, it is necessary to get the required SRF components before running any of the examples. The QSG supports two methods for getting the SRF components: installing via Conda and building from source.
+## Environment Setup
 
-### Installing via Conda [preferred]
-Installing via Conda is the easiest method for getting the SRF components and supports both the Python and C++ bindings. To install the SRF conda package and build the C++ and Hybrid components, follow the steps below:
+To get started with the Quick Start Guide, it is necessary to install the required SRF components and dependencies before running any of the examples. Similar to the SRF library, this tutorial supports installation either via Conda (preferred) or by building from source.
+
+### Installing Examples via Conda
+
+If you've alredy followed the SRF library installation instructions in the [main project README](../../README.md), you've most likely already created a Conda environment from which either `srf` (Python) or `libsrf` (C++) was installed. In this case, you can install the QSG dependencies and build the examples with:
 
 ```bash
 # Change directory to the quickstart root
 cd ${SRF_HOME}/docs/quickstart/
 
-# If needed, create a new conda environment
+# Update the existing SRF conda environment. Here, we assume the environment is named `srf`, but you can change this to the environment name you used, if different
+conda env update -n srf -f environment_cpp.yml
+conda activate srf
+
+# Build the QSG including the C++ examples
+./compile.sh
+
+# Install Python module (srf_qs_python) to build the SRF QSG Python examples
+pip install -e python
+```
+
+If you haven't installed SRF or would like to create an entirely new Conda environment for the Quick Start Guide, run:
+```bash
+# Change directory to the quickstart root
+cd ${SRF_HOME}/docs/quickstart/
+
+# Create a new SRF conda environment. Here, we assume the environment is named `srf-quickstart`
 conda env create -n srf-quickstart -f environment_cpp.yml
 conda activate srf-quickstart
 
-# Or if reusing a conda environment, ensure all dependencies are installed
-conda env update -n srf-quickstart -f environment_cpp.yml
-conda activate srf-quickstart
-
-# Compile the QSG. This will build the C++ and Hybrid components in ./build. And install the Python and Hybrid libraries
+# Build the QSG including the C++ examples
 ./compile.sh
+
+# Install Python module (srf_qs_python) to build the SRF QSG Python examples
+pip install -e python
 ```
 
-### Building from Source [advanced]
-Installing via the source is for more advanced users and is necessary to try SRF features before an official release. To install SRF from source, follow the [build instructions](../../CONTRIBUTING.md#setting-up-your-build-environment) in the [CONTRIBUTING](./../CONTRIBUTING.md) guide.
+**Note**:
+If you encounter errors building the examples, this is mostly likely caused for two reasons:
+1. You forgot to activate your Conda environment prior to running `./compile.sh`
+2. There's a stale build lingering which needs to be cleared with `rm -rf build` before running `./compile.sh` again
 
-**Note:** When building with this method, the CMake configure option `-DSRF_BUILD_DOCS:BOOL=ON` will build and install all of the necessary packages to run every example in the QSG during the source file compilation. If this option is used, the "Setup" steps in the Python, C++ and Hybrid sections below can be skipped.
+### Installing Examples via Source
 
-## Python Quickstart
+A comprehensive overview of building SRF from source is provided in the [SRF README](../../README.md). To build the Quick Start Guide examples, simply run
+
+```bash
+cd ${SRF_HOME}/docs/quickstart
+
+# Build the QSG including the C++ examples
+./compile.sh
+
+# Install Python module (srf_qs_python) to build the SRF QSG Python examples
+pip install -e python
+```
+
+## Python SRF Examples
 
 For users interested in using SRF from Python, the QSG provides several examples in the `docs/quickstart/python/srf_qs_python` directory. These examples are organized into separate folders each showing a different topic. Each example directory has a name with the format, `ex##_${EXAMPLE_NAME}`, where `XX` represents the example number (in increasing complexity) and `${EXAMPLE_NAME}` is the example name. Below is a list of the available examples and a brief description:
 
@@ -43,22 +87,6 @@ For users interested in using SRF from Python, the QSG provides several examples
 | 01 | [custom_data](./python/srf_qs_python/ex01_custom_data/README.md) | Similar to simple_pipeline, but passes a custom data type between nodes |
 | 02 | [reactive_operators](./python/srf_qs_python/ex02_reactive_operators/README.md) | Demonstrates how to use Reactive style operators inside of nodes for more complex functionality |
 | 03 | [config_options](./python/srf_qs_python/ex03_config_options/README.md) | Illustrates how thread and buffer options can alter performance |
-
-### Setup
-
-Before starting with any of the examples, it's necessary to install the `srf_qs_python` package into your current conda environment.
-
-Note: This section can be skipped if `-DSRF_BUILD_DOCS:BOOL=ON` was included in the "Getting Started" -> "Build from Source" section.
-
-To install the python `srf_qs_python` package, run the following command:
-
-```bash
-# Change directory to the repo root
-cd ${SRF_HOME}
-
-# Pip install the package
-pip install -e docs/quickstart/python
-```
 
 Once installed, the examples can be run from any directory.
 
@@ -87,7 +115,7 @@ optional arguments:
 ```
 
 
-## C++ Quickstart
+## C++ SRF Examples
 
 For users interested in using SRF with C++, the QSG provides several examples in the `docs/quickstart/cpp` directory. These examples are organized into separate folders each showing a different topic. Each example directory has a name with the format, `ex##_${EXAMPLE_NAME}`, where `XX` represents the example number (in increasing complexity) and `${EXAMPLE_NAME}` is the example name. Below is a list of the available examples and a brief description:
 
@@ -119,7 +147,7 @@ This will output all built C++ examples in the `${SRF_HOME}/docs/quickstart/buil
 
 Each example directory contains a `README.md` file with information about the example. To run any of the examples, follow the instructions in the `README.md` for launching the example.
 
-## Hybrid Quickstart
+## Hybrid (Python and C++) SRF Examples
 
 For users interested in using SRF in a hybrid environment with both C++ and Python, the QSG provides several examples in the `docs/quickstart/hybrid/srf_qs_hybrid` directory. These examples are organized into separate folders each showing a different topic. Each example directory has a name with the format, `ex##_${EXAMPLE_NAME}`, where `XX` represents the example number (in increasing complexity) and `${EXAMPLE_NAME}` is the example name. Below is a list of the available examples and a brief description:
 

--- a/docs/quickstart/README.md
+++ b/docs/quickstart/README.md
@@ -10,13 +10,8 @@ The SRF Quick Start Guide (QSG) provides Python, C++, and Hybrid (Python and C++
   - [Installing Examples via Conda](#installing-examples-via-conda)
   - [Installing Examples via Source](#installing-examples-via-source)
 - [Python SRF Examples](#python-srf-examples)
-  - [Running the Examples](#running-the-examples)
 - [C++ SRF Examples](#c-srf-examples)
-  - [Setup](#setup)
-  - [Running the Examples](#running-the-examples-1)
 - [Hybrid (Python and C++) SRF Examples](#hybrid-python-and-c-srf-examples)
-  - [Setup](#setup-1)
-  - [Running the Examples](#running-the-examples-2)
 
 
 ## Environment Setup
@@ -25,7 +20,7 @@ To get started with the Quick Start Guide, it is necessary to install the requir
 
 ### Installing Examples via Conda
 
-If you've alredy followed the SRF library installation instructions in the [main project README](../../README.md), you've most likely already created a Conda environment from which either `srf` (Python) or `libsrf` (C++) was installed. In this case, you can install the QSG dependencies and build the examples with:
+If you've alredy followed the SRF library installation instructions in the [main project README](../../README.md#installation), you've most likely already created a Conda environment from which either `srf` (Python) or `libsrf` (C++) was installed. In this case, you can install the QSG dependencies and build the examples with:
 
 ```bash
 # Change directory to the quickstart root
@@ -65,7 +60,7 @@ If you encounter errors building the examples, this is mostly likely caused for 
 
 ### Installing Examples via Source
 
-A comprehensive overview of building SRF from source is provided in the [SRF README](../../README.md). To build the Quick Start Guide examples, simply run
+A comprehensive overview of building SRF from source is provided in the [SRF README](../../README.md#source-installation). To build the Quick Start Guide examples, simply run
 
 ```bash
 cd ${SRF_HOME}/docs/quickstart
@@ -90,9 +85,10 @@ For users interested in using SRF from Python, the QSG provides several examples
 
 Once installed, the examples can be run from any directory.
 
-### Running the Examples
+<!-- omit in toc -->
+### Running the Python SRF Examples
 
-Each example directory contains a `README.md` file with information about the example and a `run.py` python file. To run any of the examples, simply launch the `run.py` file from python:
+Each example directory contains a `README.md` file with information about the example and a `run.py` Python file. To run any of the examples, simply launch the `run.py` file from python:
 
 ```bash
 python docs/quickstart/python/srf_qs_python/**ex##_ExampleName**/run.py
@@ -114,7 +110,6 @@ optional arguments:
   --threads THREADS     The number of threads to use.
 ```
 
-
 ## C++ SRF Examples
 
 For users interested in using SRF with C++, the QSG provides several examples in the `docs/quickstart/cpp` directory. These examples are organized into separate folders each showing a different topic. Each example directory has a name with the format, `ex##_${EXAMPLE_NAME}`, where `XX` represents the example number (in increasing complexity) and `${EXAMPLE_NAME}` is the example name. Below is a list of the available examples and a brief description:
@@ -125,25 +120,8 @@ For users interested in using SRF with C++, the QSG provides several examples in
 | 01 | [node_library](./cpp/ex01_node_library/README.md) | Illustrates hopw to create SRF components in a reusable library |
 | 02 | [pipeline_with_library](./cpp/ex02_pipeline_with_library/README.md) | Demonstrates how to use the SRF components from Example #01 in a SRF Pipeline |
 
-### Setup
-
-Before starting with any of the examples, it's necessary to build the C++ examples.
-
-Note: This section can be skipped if `-DSRF_BUILD_DOCS:BOOL=ON` was included in the "Getting Started" -> "Build from Source" section.
-
-To build the C++ examples, run the following command:
-
-```bash
-# Change directory to the repo root
-cd ${SRF_HOME}/docs/quickstart
-
-# Compile the C++ examples
-./compile.sh
-```
-
-This will output all built C++ examples in the `${SRF_HOME}/docs/quickstart/build` folder which will be referred to as `BUILD_DIR`.
-
-### Running the Examples
+<!-- omit in toc -->
+### Running the C++ SRF Examples
 
 Each example directory contains a `README.md` file with information about the example. To run any of the examples, follow the instructions in the `README.md` for launching the example.
 
@@ -157,25 +135,8 @@ For users interested in using SRF in a hybrid environment with both C++ and Pyth
 | 01 | [wrap_nodes](./hybrid/srf_qs_hybrid/ex01_wrap_nodes/README.md) | How to run a pipeline in Python using sources, sinks, and nodes defined in C++ |
 | 02 | [mixed_execution](./hybrid/srf_qs_hybrid/ex02_mixed_execution/README.md) | How to run a pipeline with some nodes in python and others in C++ |
 
-### Setup
-
-Before starting with any of the examples, it's necessary to install the `srf_qs_hybrid` package into your current conda environment.
-
-Note: This section can be skipped if `-DSRF_BUILD_DOCS:BOOL=ON` was included in the "Getting Started" -> "Build from Source" section.
-
-To install the python `srf_qs_hybrid` package, run the following command:
-
-```bash
-# Change directory to the repo root
-cd ${SRF_HOME}/docs/quickstart
-
-# Compile the C++ examples
-./compile.sh
-```
-
-Once installed, the examples can be run from any directory.
-
-### Running the Examples
+<!-- omit in toc -->
+### Running the Hybrid SRF Examples
 
 Each example directory contains a `README.md` file with information about the example and a `run.py` python file. To run any of the examples, simply launch the `run.py` file from python:
 

--- a/docs/quickstart/README.md
+++ b/docs/quickstart/README.md
@@ -1,16 +1,9 @@
-# SRF Quick Start Guide (QSG)
+# SRF Quick Start Guide
+:surfer: Learn to SRF and Catch the Wave to Accelerating Streaming Pipelines :surfer:
 
-The SRF Quick Start Guide (QSG) provides examples on how to start using SRF via the Python bindings, C++ bindings or both.
+The SRF Quick Start Guide (QSG) provides examples on how to get started using SRF. The goal of this tutorial is to provide a gentle on-ramp to building applications with SRF and is targeted towards a wide person of developers - ranging from data scientists to performance engineers.
 
-## Prerequisites
-
-- Pascal architecture (Compute capability 6.0) or better
-- NVIDIA driver `450.80.02` or higher
-- [conda or miniconda](https://conda.io/projects/conda/en/latest/user-guide/install/linux.html)
-  - **Note:** Conda performance can be improved by using [Mamba](https://github.com/mamba-org/mamba) and is recommended for the QSG. If you have `mamba` installed, simply replace `conda`  with `mamba` in the installation instructions.
-- if using docker:
-  - [Docker](https://docs.docker.com/get-docker/)
-  - [The NVIDIA container toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker)
+## Table of Contents
 
 ## Getting Started
 


### PR DESCRIPTION
Update of QSG that focuses primarily on:
- Removal of redundant install information provided in the main SRF README
- Improved organization (added TOC and streamlined prose)
- Typo fixes

Targeting branch 22.08 with this, but we should also merge to 22.06