### PR TITLE
Transient Pool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,6 +147,7 @@ add_library(libsrf
   src/internal/executor/iexecutor.cpp
   src/internal/memory/device_resources.cpp
   src/internal/memory/host_resources.cpp
+  src/internal/memory/transient_pool.cpp
   src/internal/network/resources.cpp
   src/internal/pipeline/controller.cpp
   src/internal/pipeline/instance.cpp

--- a/src/internal/memory/transient_pool.cpp
+++ b/src/internal/memory/transient_pool.cpp
@@ -32,6 +32,20 @@ TransientBuffer::~TransientBuffer()
     release();
 }
 
+TransientBuffer::TransientBuffer(TransientBuffer&& other) noexcept :
+  m_addr(std::exchange(other.m_addr, nullptr)),
+  m_bytes(std::exchange(other.m_bytes, 0UL)),
+  m_buffer(std::move(other.m_buffer))
+{}
+
+TransientBuffer& TransientBuffer::operator=(TransientBuffer&& other) noexcept
+{
+    m_addr   = std::exchange(other.m_addr, nullptr);
+    m_bytes  = std::exchange(other.m_bytes, 0UL);
+    m_buffer = std::move(other.m_buffer);
+    return *this;
+}
+
 void* TransientBuffer::data()
 {
     return m_addr;

--- a/src/internal/memory/transient_pool.cpp
+++ b/src/internal/memory/transient_pool.cpp
@@ -27,6 +27,11 @@ TransientBuffer::TransientBuffer(void* addr, std::size_t bytes, srf::data::Share
   m_buffer(std::move(buffer))
 {}
 
+TransientBuffer::~TransientBuffer()
+{
+    release();
+}
+
 void* TransientBuffer::data()
 {
     return m_addr;
@@ -39,9 +44,12 @@ std::size_t TransientBuffer::bytes() const
 
 void TransientBuffer::release()
 {
-    m_addr  = nullptr;
-    m_bytes = 0;
-    m_buffer.release();
+    if (m_addr != nullptr)
+    {
+        m_addr  = nullptr;
+        m_bytes = 0;
+        m_buffer.release();
+    }
 }
 
 TransientPool::TransientPool(std::size_t block_size,

--- a/src/internal/memory/transient_pool.cpp
+++ b/src/internal/memory/transient_pool.cpp
@@ -1,0 +1,86 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "internal/memory/transient_pool.hpp"
+
+#include "srf/memory/resources/memory_resource.hpp"
+
+namespace srf::internal::memory {
+
+TransientBuffer::TransientBuffer(void* addr, std::size_t bytes, srf::data::SharedReusable<srf::memory::buffer> buffer) :
+  m_addr(addr),
+  m_bytes(bytes),
+  m_buffer(std::move(buffer))
+{}
+
+void* TransientBuffer::data()
+{
+    return m_addr;
+}
+
+std::size_t TransientBuffer::bytes() const
+{
+    return m_bytes;
+}
+
+void TransientBuffer::release()
+{
+    m_addr  = nullptr;
+    m_bytes = 0;
+    m_buffer.release();
+}
+
+TransientPool::TransientPool(std::size_t block_size,
+                             std::size_t block_count,
+                             std::size_t capacity,
+                             std::shared_ptr<srf::memory::memory_resource> mr) :
+  m_block_size(block_size),
+  m_pool(srf::data::ReusablePool<srf::memory::buffer>::create(capacity))
+{
+    CHECK(m_pool);
+    CHECK_LT(block_count, capacity);
+    for (int i = 0; i < block_count; i++)
+    {
+        m_pool->emplace(block_size, mr);
+    }
+}
+
+TransientBuffer TransientPool::await_buffer(std::size_t bytes)
+{
+    if (bytes > m_block_size)  // todo(#54) [[unlikely]]
+    {
+        LOG(ERROR) << "requesting allocation larger than max_size";
+        throw std::bad_alloc{};
+    }
+
+    if (m_remaining < bytes)
+    {
+        auto buffer = m_pool->await_item();
+        m_addr      = static_cast<std::byte*>(buffer->data());
+        m_remaining = buffer->bytes();
+        m_buffer    = std::move(buffer);
+    }
+
+    // align + bytes
+    void* addr = m_addr;
+    m_addr += bytes;
+    m_remaining -= bytes;
+
+    return TransientBuffer(addr, bytes, m_buffer);
+}
+
+}  // namespace srf::internal::memory

--- a/src/internal/memory/transient_pool.hpp
+++ b/src/internal/memory/transient_pool.hpp
@@ -1,0 +1,142 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "srf/data/reusable_pool.hpp"
+#include "srf/memory/buffer.hpp"
+#include "srf/memory/resources/memory_resource.hpp"
+#include "srf/utils/macros.hpp"
+
+#include <glog/logging.h>
+
+#include <cstddef>
+#include <new>
+#include <utility>
+
+namespace srf::internal::memory {
+
+/**
+ * @brief A short-lived buffer based on a portion of a data::SharedResable<memory::buffer>
+ *
+ * @see TransientPool for more details.
+ */
+
+class TransientBuffer
+{
+  public:
+    TransientBuffer(void* addr, std::size_t bytes, srf::data::SharedReusable<srf::memory::buffer> buffer);
+
+    DELETE_COPYABILITY(TransientBuffer);
+    DEFAULT_MOVEABILITY(TransientBuffer);
+
+    void* data();
+    std::size_t bytes() const;
+
+    void release();
+
+  private:
+    void* m_addr;
+    std::size_t m_bytes;
+    srf::data::SharedReusable<srf::memory::buffer> m_buffer;
+};
+
+/**
+ * @brief A short-lived object T allocated into the static storage of a TransientBuffer.
+ *
+ * @see TransientPool and TransientBuffer for more details.
+ */
+
+template <typename T>
+class Transient final : private TransientBuffer
+{
+  public:
+    Transient(TransientBuffer&& buffer) : TransientBuffer(std::move(buffer))
+    {
+        CHECK_LT(sizeof(T), bytes());
+        void* addr       = data();
+        std::size_t size = bytes();
+        addr             = std::align(alignof(T), sizeof(T), addr, size);
+        CHECK(addr);
+        m_data = new (addr) T;
+    }
+
+    T& operator*()
+    {
+        CHECK(m_data);
+        return *m_data;
+    }
+
+    T* operator->()
+    {
+        CHECK(m_data);
+        return m_data;
+    }
+
+    void release()
+    {
+        if (m_data)
+        {
+            m_data->~T();
+            m_data = nullptr;
+            TransientBuffer::release();
+        }
+    }
+
+  private:
+    T* m_data;
+};
+
+/**
+ * @brief ReusablePool of memory::buffers that are used as reusable reference-counted monotonic memory resources
+ *
+ * TransientPool is a ReusablePool of memory::buffers from which smaller buffers are allocated similar to a monotonic
+ * memory resource, i.e. pointer pusing stack; however the TransientBuffer or Transient<T> object pull from the pool
+ * hold a SharedReusable<memory::buffer> which keeps the entire monotonic stack from returning to the resuable pool
+ * until all objects created on a given stack are deallocated.
+ *
+ * Allocation of Transisent object should be incredibly fast; even faster than the Reusable/SharedResuable on which they
+ * are based, since a single Reusable<memory::buffer> might back 10s-1000s of allocations dependending on size.
+ *
+ * It is critical that all Transient object allocated from a pool have similar life cycles
+ */
+class TransientPool
+{
+  public:
+    TransientPool(std::size_t block_size,
+                  std::size_t block_count,
+                  std::size_t capacity,
+                  std::shared_ptr<srf::memory::memory_resource> mr);
+
+    TransientBuffer await_buffer(std::size_t bytes);
+
+    template <typename T>
+    Transient<T> await_object()
+    {
+        auto buffer = await_buffer(sizeof(T) + alignof(T));
+        return Transient<T>(std::move(buffer));
+    }
+
+  private:
+    const std::size_t m_block_size;
+    const std::shared_ptr<srf::data::ReusablePool<srf::memory::buffer>> m_pool;
+    std::byte* m_addr{nullptr};
+    std::size_t m_remaining{0};
+    srf::data::SharedReusable<srf::memory::buffer> m_buffer;
+};
+
+}  // namespace srf::internal::memory

--- a/src/internal/memory/transient_pool.hpp
+++ b/src/internal/memory/transient_pool.hpp
@@ -40,6 +40,7 @@ class TransientBuffer
 {
   public:
     TransientBuffer(void* addr, std::size_t bytes, srf::data::SharedReusable<srf::memory::buffer> buffer);
+    ~TransientBuffer();
 
     DELETE_COPYABILITY(TransientBuffer);
     DEFAULT_MOVEABILITY(TransientBuffer);
@@ -75,6 +76,11 @@ class Transient final : private TransientBuffer
         m_data = new (addr) T;
     }
 
+    ~Transient()
+    {
+        release();
+    }
+
     T& operator*()
     {
         CHECK(m_data);
@@ -89,7 +95,7 @@ class Transient final : private TransientBuffer
 
     void release()
     {
-        if (m_data)
+        if (m_data != nullptr)
         {
             m_data->~T();
             m_data = nullptr;


### PR DESCRIPTION
```cpp
/**
 * @brief ReusablePool of memory::buffers that are used as reusable reference-counted monotonic memory resources
 *
 * TransientPool is a ReusablePool of memory::buffers from which smaller buffers are allocated similar to a monotonic
 * memory resource, i.e. pointer pusing stack; however the TransientBuffer or Transient<T> object pulled from the pool
 * hold a SharedReusable<memory::buffer> which keeps the entire monotonic stack from returning to the ReusablePool
 * until all transient objects created on a given stack are deallocated.
 *
 * Allocation of Transient object should be incredibly fast; even faster than the Reusable/SharedResuable on which they
 * are based, since a single Reusable<memory::buffer> might back 10s-1000s of allocations depending on size.
 *
 * It is critical that all Transient object allocated from a pool have similar life cycles
 */
```