### PR TITLE
fix faulty assumption about remote key sizes

### DIFF
--- a/src/tests/test_network.cpp
+++ b/src/tests/test_network.cpp
@@ -119,8 +119,9 @@ TEST_F(TestNetwork, ResourceManager)
     EXPECT_TRUE(d_ucx_block.remote_handle());
     EXPECT_TRUE(d_ucx_block.remote_handle_size());
 
-    // this is generally true, but perhaps we should not count on it
-    EXPECT_LE(h_ucx_block.remote_handle_size(), d_ucx_block.remote_handle_size());
+    // the following can not assumed to be true
+    // the remote handle size is proportional to the number and types of ucx transports available in a given domain
+    // EXPECT_LE(h_ucx_block.remote_handle_size(), d_ucx_block.remote_handle_size());
 
     // expect that the buffers are allowed to survive pass the resource manager
     resources.reset();


### PR DESCRIPTION
I had put an assumption that the memory required to store UCX remote keys for GPU memory would always be larger than for Host memory.

This assumption is incorrect. The size of buffer for the keys is dependent on which transports are enable, the number of NICs, the number of GPUs and a variety of other runtime variables used to initialize UCX.

I've left a comment in the tests to remind developers and users of that fact.
