### PR TITLE
Adjust contrib instructions for pip install location

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ $SRF_HOME/build/tests/logging/test_srf_logging.x
 
 ### Install SRF Python
 ```bash
-pip install -e $SRF_HOME/python
+pip install -e $SRF_HOME/build/python
 ```
 
 #### Run SRF Python Tests

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ $SRF_HOME/build/tests/logging/test_srf_logging.x
 <!-- omit in toc -->
 #### Install SRF Python Bindings
 ```bash
-pip install -e $SRF_HOME/python
+pip install -e $SRF_HOME/build/python
 ```
 <!-- omit in toc -->
 #### Run SRF Python Tests


### PR DESCRIPTION
pip install from the build/python dir, not $SRF_HOME/python

Not sure if we need to even mention SRF_PYTHON_INPLACE_BUILD var

@mdemoret-nv 