### PR TITLE
[gpuCI] Forward-merge branch-22.08 to branch-22.09 [skip gpuci]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ option(SRF_USE_CONDA "Enables finding dependencies via conda instead of vcpkg. N
 option(SRF_USE_IWYU "Enable running include-what-you-use as part of the build process" OFF)
 option(SRF_ENABLE_CODECOV "Enable gcov code coverage" OFF)
 
-set(SRF_RAPIDS_VERSION "22.06" CACHE STRING "Which version of RAPIDS to build for. Sets default versions for RAPIDS CMake and RMM.")
+set(SRF_RAPIDS_VERSION "22.08" CACHE STRING "Which version of RAPIDS to build for. Sets default versions for RAPIDS CMake and RMM.")
 
 set(SRF_CACHE_DIR "${CMAKE_SOURCE_DIR}/.cache" CACHE PATH "Directory to contain all CPM and CCache data")
 mark_as_advanced(SRF_CACHE_DIR)
@@ -58,7 +58,7 @@ endif()
 rapids_cuda_init_architectures(srf)
 
 project(srf
-  VERSION 22.06.00
+  VERSION 22.08.00
   LANGUAGES C CXX
 )
 

--- a/ci/conda/environments/dev_env.yml
+++ b/ci/conda/environments/dev_env.yml
@@ -27,7 +27,8 @@ dependencies:
   - jinja2=3.0
   - lcov=1.15
   - libhwloc=2.5
-  - librmm=22.06
+  - libprotobuf=3.20
+  - librmm=22.08
   - libtool
   - ninja=1.10
   - nlohmann_json=3.9

--- a/ci/conda/environments/dev_env_nogcc.yml
+++ b/ci/conda/environments/dev_env_nogcc.yml
@@ -20,7 +20,8 @@ dependencies:
   - grpc-cpp=1.45
   - gtest=1.10
   - libhwloc=2.5
-  - librmm=22.06
+  - libprotobuf=3.20
+  - librmm=22.08
   - ninja=1.10
   - nlohmann_json=3.9
   - pkg-config=0.29

--- a/ci/conda/recipes/libsrf/conda_build_config.yaml
+++ b/ci/conda/recipes/libsrf/conda_build_config.yaml
@@ -31,24 +31,18 @@ python:
 
 # Setup the dependencies to build with multiple versions of RAPIDS
 rapids_version:
-  - 21.10 # 22.06 is final release with support for RAPIDS 21.10
   - 22.04 # Keep around compatibility with current version -1
   - 22.06
+  - 22.08
 
 abseil_cpp:
   - 20211102.0
-  - 20211102.0
   - 20210324.2
-
-grpc_cpp:
-  - 1.46
-  - 1.45
-  - 1.45 # 1.45 is needed for cudf>=22.06
+  - 20210324.2
 
 zip_keys:
   - rapids_version
   - abseil_cpp
-  - grpc_cpp
 
 # The following mimic what is available in the pinning feedstock:
 # https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/main/recipe/conda_build_config.yaml
@@ -60,6 +54,10 @@ gflags:
   - 2.2
 glog:
   - 0.6
+grpc_cpp:
+  - 1.45
+libprotobuf:
+  - 3.20
 ucx:
   - 1.12
 

--- a/cmake/import_rapids_cmake.cmake
+++ b/cmake/import_rapids_cmake.cmake
@@ -16,7 +16,7 @@
 # Ensure this is only run once
 include_guard(GLOBAL)
 
-set(RAPIDS_CMAKE_VERSION "22.06" CACHE STRING "Version of rapids-cmake to use")
+set(RAPIDS_CMAKE_VERSION "22.08" CACHE STRING "Version of rapids-cmake to use")
 
 # Download and load the repo according to the rapids-cmake instructions if it does not exist
 if(NOT EXISTS ${CMAKE_BINARY_DIR}/RAPIDS_CMAKE.cmake)

--- a/docs/quickstart/CMakeLists.txt
+++ b/docs/quickstart/CMakeLists.txt
@@ -25,7 +25,7 @@ list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../cmake")
 include(import_rapids_cmake)
 
 project(srf-quickstart
-  VERSION 22.06.00
+  VERSION 22.08.00
   LANGUAGES C CXX
 )
 

--- a/docs/quickstart/environment_cpp.yml
+++ b/docs/quickstart/environment_cpp.yml
@@ -30,7 +30,7 @@ dependencies:
   - python=3.8
   - scikit-build>=0.12
   - spdlog=1.8.5
-  - srf=22.06
+  - srf=22.08
   - sysroot_linux-64=2.17
   - pip:
     - cython


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.08` that creates a PR to keep `branch-22.09` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.