### PR TITLE
Bump Versions 22.09

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ endif()
 rapids_cuda_init_architectures(srf)
 
 project(srf
-  VERSION 22.08.00
+  VERSION 22.09.00
   LANGUAGES C CXX
 )
 
@@ -115,7 +115,7 @@ endif()
 set(CMAKE_EXPORT_COMPILE_COMMANDS OFF)
 
 # Create a custom target to allow preparing for style checks
-add_custom_target(style_checks
+add_custom_target(${PROJECT_NAME}_style_checks
   COMMENT "Building dependencies for style checks"
 )
 

--- a/ci/scripts/jenkins/checks.sh
+++ b/ci/scripts/jenkins/checks.sh
@@ -53,7 +53,7 @@ gpuci_logger "Configuring CMake"
 cmake -B build -G Ninja ${CMAKE_BUILD_ALL_FEATURES} .
 
 gpuci_logger "Building targets that generate source code"
-cmake --build build --target style_checks --parallel ${PARALLEL_LEVEL}
+cmake --build build --target srf_style_checks --parallel ${PARALLEL_LEVEL}
 
 gpuci_logger "Running C++ style checks"
 ${SRF_ROOT}/ci/scripts/cpp_checks.sh

--- a/cmake/deps/Configure_hwloc.cmake
+++ b/cmake/deps/Configure_hwloc.cmake
@@ -151,7 +151,7 @@ function(find_and_configure_hwloc version)
       add_dependencies(hwloc::hwloc hwloc)
 
       # Finally, add this to the style check dependencies
-      add_dependencies(style_checks hwloc-install)
+      add_dependencies(${PROJECT_NAME}_style_checks hwloc-install)
 
     endif()
   endif()

--- a/cmake/deps/Configure_ucx.cmake
+++ b/cmake/deps/Configure_ucx.cmake
@@ -166,7 +166,7 @@ function(find_and_configure_ucx version)
     )
 
     # Finally, add this to the style check dependencies
-    add_dependencies(style_checks ucx-install)
+    add_dependencies(${PROJECT_NAME}_style_checks ucx-install)
   else()
     # Found installed UCX. Make sure to call rapids_export_package without a version.
     # Otherwise CMake fails with trying to add the dependency twice

--- a/cmake/import_rapids_cmake.cmake
+++ b/cmake/import_rapids_cmake.cmake
@@ -16,7 +16,7 @@
 # Ensure this is only run once
 include_guard(GLOBAL)
 
-set(RAPIDS_CMAKE_VERSION "22.08" CACHE STRING "Version of rapids-cmake to use")
+set(RAPIDS_CMAKE_VERSION "${SRF_RAPIDS_VERSION}" CACHE STRING "Version of rapids-cmake to use")
 
 # Download and load the repo according to the rapids-cmake instructions if it does not exist
 if(NOT EXISTS ${CMAKE_BINARY_DIR}/RAPIDS_CMAKE.cmake)

--- a/docs/quickstart/CMakeLists.txt
+++ b/docs/quickstart/CMakeLists.txt
@@ -25,7 +25,7 @@ list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../cmake")
 include(import_rapids_cmake)
 
 project(srf-quickstart
-  VERSION 22.08.00
+  VERSION 22.09.00
   LANGUAGES C CXX
 )
 

--- a/docs/quickstart/environment_cpp.yml
+++ b/docs/quickstart/environment_cpp.yml
@@ -30,7 +30,7 @@ dependencies:
   - python=3.8
   - scikit-build>=0.12
   - spdlog=1.8.5
-  - srf=22.08
+  - srf=22.09
   - sysroot_linux-64=2.17
   - pip:
     - cython

--- a/protos/CMakeLists.txt
+++ b/protos/CMakeLists.txt
@@ -64,7 +64,7 @@ set_target_properties(
 )
 
 # Finally, add this to the style check dependencies
-add_dependencies(style_checks srf_protos-headers-target)
+add_dependencies(${PROJECT_NAME}_style_checks srf_protos-headers-target)
 
 install(
   TARGETS srf_protos srf_architect_protos

--- a/tools/nvrpc/tests/CMakeLists.txt
+++ b/tools/nvrpc/tests/CMakeLists.txt
@@ -57,7 +57,7 @@ target_link_libraries(test_nvrpc
 )
 
 # Finally, add this to the style check dependencies
-add_dependencies(style_checks nvrpc-testing-protos-headers-target)
+add_dependencies(${PROJECT_NAME}_style_checks nvrpc-testing-protos-headers-target)
 
 add_test(
   NAME nvrpc


### PR DESCRIPTION
This PR bumps the SRF versions from 22.08 to 22.09.

Note: All RAPIDS versions are left at 22.08 and will lag behind by 1 calver from here on out.