### PR TITLE
Add documentation on how to build the doxygen docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ More information can be found at: [Contributor Code of Conduct](CODE_OF_CONDUCT.
 
 1. Find an issue to work on. The best way is to look for issues with the [good first issue](https://github.com/NVIDIA/SRF/issues) label.
 2. Comment on the issue stating that you are going to work on it.
-3. Code! Make sure to update unit tests and confirm that test coverage has not decreased (see below)! Ensure the 
+3. Code! Make sure to update unit tests and confirm that test coverage has not decreased (see below)! Ensure the
 [license headers are set properly](#Licensing).
 4. When done, [create your pull request](https://github.com/NVIDIA/SRF/compare).
 5. Wait for other developers to review your code and update code as needed.
@@ -37,7 +37,7 @@ Remember, if you are unsure about anything, don't hesitate to comment on issues 
 
 ## Unit testing and Code Coverage
 Prior to submitting a pull request, you should ensure that all your contributed code is covered by unit tests, and that
-unit test coverage percentages have not decreased (even better if they've increased). To test, from the SRF root 
+unit test coverage percentages have not decreased (even better if they've increased). To test, from the SRF root
 directory:
 
 1. Generate a code coverage report and ensure your additions are covered.
@@ -112,6 +112,13 @@ pip install -e $SRF_HOME/build/python
 #### Run SRF Python Tests
 ```bash
 pytest $SRF_HOME/python
+```
+
+### Building API Documentation
+From the root of the SRF repo, configure CMake with `SRF_BUILD_DOCS=ON` then build the `srf_docs` target. Once built the documentation will be located in the `build/docs/html` directory.
+```bash
+cmake -B build -DSRF_BUILD_DOCS=ON .
+cmake --build build --target srf_docs
 ```
 
 ## Licensing


### PR DESCRIPTION
Looks like VSCode decided to remove two white-space chars.

fixes #127