### PR TITLE
Fix tests so that the proper upstream build is used for the coverage test

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -100,7 +100,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        build_type: ["Debug", "Release"]
+        build_cc: ["gcc", "gcc-coverage"]
 
     steps:
       - name: Checkout
@@ -109,10 +109,10 @@ jobs:
           lfs: false
           path: 'srf'
 
-      - name: Test:linux:x86_64:gcc
+      - name: Test:linux:x86_64
         shell: bash
         env:
-          BUILD_TYPE: ${{ matrix.build_type }}
+          BUILD_CC: ${{ matrix.build_cc }}
         run: ./srf/ci/scripts/github/test.sh
 
   documentation:

--- a/ci/scripts/github/test.sh
+++ b/ci/scripts/github/test.sh
@@ -35,11 +35,13 @@ mkdir -p ${WORKSPACE_TMP}/reports
 
 # ctest requires cmake to be configured in order to locate tests
 
-if [[ "${BUILD_TYPE}" == "Debug" ]]; then
-  cmake -B build -G Ninja ${CMAKE_BUILD_ALL_FEATURES} ${CMAKE_BUILD_WITH_CODECOV} .
+if [[ "${BUILD_CC}" == "gcc-coverage" ]]; then
+  CMAKE_FLAGS="${CMAKE_BUILD_ALL_FEATURES} ${CMAKE_BUILD_WITH_CODECOV}"
 else
-  cmake -B build -G Ninja ${CMAKE_BUILD_ALL_FEATURES} .
+  CMAKE_FLAGS="${CMAKE_BUILD_ALL_FEATURES}"
 fi
+
+cmake -B build -G Ninja ${CMAKE_FLAGS} .
 
 gpuci_logger "Running C++ Tests"
 cd ${SRF_ROOT}/build


### PR DESCRIPTION
As far as I can tell this bug also existed in the Jenkins CI.