### PR TITLE
Allow building build without GPU and without a driver

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -84,6 +84,7 @@ jobs:
         shell: bash
         env:
           BUILD_CC: ${{ matrix.build_cc }}
+          SRF_IGNORE_NO_GPU: 1
         run: ./srf/ci/scripts/github/build.sh
 
   test:

--- a/src/internal/system/device_info.cpp
+++ b/src/internal/system/device_info.cpp
@@ -25,6 +25,7 @@
 
 #include <array>
 #include <cstddef>
+#include <cstdlib>
 #include <memory>
 #include <ostream>
 #include <set>
@@ -50,6 +51,14 @@ struct NvmlState
                             "initialized";
             return;
         default:
+            if (std::getenv("SRF_IGNORE_NO_GPU") != nullptr)
+            {
+                LOG(WARNING)
+                    << "NVML: Access to the NVIDIA GPU driver failed; setting DeviceCount to 0, CUDA will not be "
+                       "initialized";
+                return;
+            }
+
             LOG(FATAL) << "NVML_ERROR_UNKNOWN: is a hard fail";
         }
 

--- a/src/internal/system/device_info.cpp
+++ b/src/internal/system/device_info.cpp
@@ -53,9 +53,6 @@ struct NvmlState
         default:
             if (std::getenv("SRF_IGNORE_NO_GPU") != nullptr)
             {
-                LOG(WARNING)
-                    << "NVML: Access to the NVIDIA GPU driver failed; setting DeviceCount to 0, CUDA will not be "
-                       "initialized";
                 return;
             }
 


### PR DESCRIPTION
Allows building SRF without a gpu or a driver present when the `SRF_IGNORE_NO_GPU` environment variable is defined.

Currently we build with an image containing the Nvidia driver which pulls in several deps. This change would allow us to build with slimmer images.