### PR TITLE
change pull_request to pull_request_target

### DIFF
--- a/.github/workflows/add_to_project.yml
+++ b/.github/workflows/add_to_project.yml
@@ -5,7 +5,7 @@ on:
     types:
       - opened
 
-  pull_request:
+  pull_request_target:
     types:
       - opened
 


### PR DESCRIPTION
The current action uses `on: pull_request` but for it to work successfully, it needs to be `on: pull_request_target`

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target