### PR TITLE
Improve NVML + MIG Behavior

### DIFF
--- a/src/internal/system/device_info.cpp
+++ b/src/internal/system/device_info.cpp
@@ -32,25 +32,26 @@
 
 #define TEST_BIT(_n, _p) (_n & (1UL << _p))
 
+#define SRF_CHECK_NVML(expression)                                    \
+    {                                                                 \
+        auto status = (expression);                                   \
+        if (status != NVML_SUCCESS)                                   \
+        {                                                             \
+            LOG(FATAL) << "NVML failed: " << nvmlErrorString(status); \
+        }                                                             \
+    }
+
 namespace {
 struct NvmlState
 {
     NvmlState()
     {
-        switch (nvmlInit_v2())
+        auto nvml_status = nvmlInit_v2();
+        if (nvml_status != NVML_SUCCESS)
         {
-        case NVML_SUCCESS:
-            break;
-        case NVML_ERROR_DRIVER_NOT_LOADED:
-            LOG(WARNING)
-                << "NVML: No NVIDIA GPU driver was detected; setting DeviceCount to 0, CUDA will not be initialized";
+            LOG(WARNING) << "NVML: Error initializing due to '" << nvmlErrorString(nvml_status)
+                         << "'. Setting DeviceCount to 0, CUDA will not be initialized";
             return;
-        case NVML_ERROR_NO_PERMISSION:
-            LOG(WARNING) << "NVML: Access to the NVIDIA GPU driver failed; setting DeviceCount to 0, CUDA will not be "
-                            "initialized";
-            return;
-        default:
-            LOG(FATAL) << "NVML_ERROR_UNKNOWN: is a hard fail";
         }
 
         unsigned int visible_devices = 0;
@@ -60,12 +61,42 @@ struct NvmlState
         for (decltype(visible_devices) i = 0; i < visible_devices; i++)
         {
             nvmlDevice_t device_handle;
+            unsigned int current_mig_mode;
+            unsigned int pending_mig_mode;
+
             auto device_status = nvmlDeviceGetHandleByIndex_v2(i, &device_handle);
             if (device_status != NVML_SUCCESS)
             {
                 LOG(WARNING) << "NVML: " << nvmlErrorString(device_status) << "; device with index " << i
                              << " will be ignored";
                 continue;
+            }
+
+            auto mig_status = nvmlDeviceGetMigMode(device_handle, &current_mig_mode, &pending_mig_mode);
+            if (mig_status == NVML_SUCCESS &&
+                (current_mig_mode == NVML_DEVICE_MIG_ENABLE || pending_mig_mode == NVML_DEVICE_MIG_ENABLE))
+            {
+                // let's treat pending as current - MIG mode cannot swap while a cuda process is active, but we may not
+                // have initailized CUDA yet, so to avoid any race conditions, we'll error on the side of caution
+                if (visible_devices == 1)
+                {
+                    // if have 1 visible device and it's in MIG mode, then we expect to see only one visible mig
+                    // instance
+                    m_using_mig = true;
+
+                    // if(number_of_visible_mig_instances == 1) {
+                    // if all conditions for running on MIG are met, then we early return from this scope
+                    // return;
+                    // }
+
+                    LOG(FATAL) << "SRF Issue #205: mig instance queries and enumeration is current not supported";
+                }
+                else
+                {
+                    LOG(WARNING) << "NVML visible device #" << i
+                                 << " has MIG mode enabled with multiple GPUs visible; this device will be ignored";
+                    continue;
+                }
             }
             m_accessible_indexes.insert(i);
         }
@@ -80,6 +111,11 @@ struct NvmlState
         return m_accessible_indexes;
     }
 
+    bool using_mig() const
+    {
+        return m_using_mig;
+    }
+
   private:
     // this object can also hold the list of device handles that we have access to.
     // - nvmlDeviceGetCount_v2 - will tell us the total number of devices we have access to, i.e. the range of [0, N)
@@ -87,6 +123,8 @@ struct NvmlState
     // which we have permission to access, the call to nvmlDeviceGetHandleByIndex_v2 may return
     // NVML_ERROR_NO_PERMISSION.
     std::set<unsigned int> m_accessible_indexes;
+
+    bool m_using_mig{false};
 };
 
 auto nvmlInstatnce = std::make_unique<NvmlState>();
@@ -175,7 +213,7 @@ std::set<unsigned int> DeviceInfo::AccessibleDeviceIndexes()
 nvmlMemory_t DeviceInfo::MemoryInfo(int device_id)
 {
     nvmlMemory_t info;
-    CHECK_EQ(nvmlDeviceGetMemoryInfo(DeviceInfo::GetHandleById(device_id), &info), NVML_SUCCESS);
+    SRF_CHECK_NVML(nvmlDeviceGetMemoryInfo(DeviceInfo::GetHandleById(device_id), &info));
     return info;
 }
 

--- a/srf.code-workspace
+++ b/srf.code-workspace
@@ -272,7 +272,9 @@
       "--rcfile=${workspaceFolder}/python/.pylintrc"
     ],
     "python.linting.pylintEnabled": true,
-    "python.sortImports.args": ["--settings-file=${workspaceFolder}/python/setup.cfg"],
+    "python.sortImports.args": [
+      "--settings-file=${workspaceFolder}/python/setup.cfg"
+    ],
     "python.testing.cwd": "${workspaceFolder}/python",
     "python.testing.pytestArgs": [
       "-s"
@@ -335,6 +337,7 @@
       "matepek.vscode-catch2-test-adapter",
       "ms-vscode.cmake-tools",
       "stkb.rewrap",
+      "formulahendry.terminal",
     ],
     // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
     "unwantedRecommendations": [


### PR DESCRIPTION
This resolves #124 when using 1 or more standard GPU devices. When multiple GPUs are visible, all MIG devices are ignored.

Issue #205 will enable running on MIG instances under the strict condition that the only visible devices is in MIG mode and that there is only 1 visible MIG instances seen by the calling processes.

Code coverage is expected to decrease because we have no MIG instances in CI.