### PR TITLE
[gpuCI] Forward-merge branch-22.11 to branch-23.01 [skip gpuci]

### DIFF
--- a/python/srf/tests/sample_modules.cpp
+++ b/python/srf/tests/sample_modules.cpp
@@ -22,6 +22,7 @@
 #include "srf/channel/status.hpp"
 #include "srf/modules/module_registry_util.hpp"
 #include "srf/node/rx_source.hpp"
+#include "srf/utils/string_utils.hpp"
 #include "srf/version.hpp"
 
 #include <boost/hana/if.hpp>
@@ -70,9 +71,7 @@ PYBIND11_MODULE(sample_modules, module)
     modules::ModelRegistryUtil::create_registered_module<srf::modules::TemplateModule<std::string>>(
         "TemplateModuleString", "srf_unittest", PybindSegmentModuleVersion);
 
-    std::stringstream sstream;
-    sstream << srf_VERSION_MAJOR << "." << srf_VERSION_MINOR << "." << srf_VERSION_PATCH;
-
-    module.attr("__version__") = sstream.str();
+    module.attr("__version__") =
+        SRF_CONCAT_STR(srf_VERSION_MAJOR << "." << srf_VERSION_MINOR << "." << srf_VERSION_PATCH);
 }
 }  // namespace srf::pysrf

--- a/python/srf/tests/test_edges.cpp
+++ b/python/srf/tests/test_edges.cpp
@@ -29,6 +29,7 @@
 #include "srf/node/source_properties.hpp"
 #include "srf/segment/builder.hpp"
 #include "srf/segment/object.hpp"
+#include "srf/utils/string_utils.hpp"
 #include "srf/version.hpp"
 
 #include <boost/fiber/future/future.hpp>
@@ -268,9 +269,7 @@ PYBIND11_MODULE(test_edges_cpp, module)
              py::arg("parent"),
              py::arg("name"));
 
-    std::stringstream sstream;
-    sstream << srf_VERSION_MAJOR << "." << srf_VERSION_MINOR << "." << srf_VERSION_PATCH;
-
-    module.attr("__version__") = sstream.str();
+    module.attr("__version__") =
+        SRF_CONCAT_STR(srf_VERSION_MAJOR << "." << srf_VERSION_MINOR << "." << srf_VERSION_PATCH);
 }
 }  // namespace srf::pytests

--- a/python/srf/tests/utils.cpp
+++ b/python/srf/tests/utils.cpp
@@ -17,9 +17,13 @@
 
 #include "pysrf/utils.hpp"
 
+#include "srf/utils/string_utils.hpp"
+#include "srf/version.hpp"
+
 #include <pybind11/cast.h>
 #include <pybind11/pybind11.h>
 
+#include <ostream>
 #include <stdexcept>
 
 namespace srf::pytests {
@@ -44,10 +48,7 @@ PYBIND11_MODULE(utils, module)
         },
         py::arg("msg") = "");
 
-#ifdef VERSION_INFO
-    m.attr("__version__") = MACRO_STRINGIFY(VERSION_INFO);
-#else
-    module.attr("__version__") = "dev";
-#endif
+    module.attr("__version__") =
+        SRF_CONCAT_STR(srf_VERSION_MAJOR << "." << srf_VERSION_MINOR << "." << srf_VERSION_PATCH);
 }
 }  // namespace srf::pytests


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.11` that creates a PR to keep `branch-23.01` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.