### PR TITLE
Add `map_async` and `flat_map_async` Operators for Python Async Generators

### DIFF
--- a/cpp/mrc/include/mrc/runnable/context.hpp
+++ b/cpp/mrc/include/mrc/runnable/context.hpp
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include "mrc/types.hpp"
 #include <glog/logging.h>
 
 #include <cstddef>
@@ -27,6 +28,7 @@
 namespace mrc::runnable {
 
 class Runner;
+class IEngine;
 enum class EngineType;
 
 /**
@@ -41,7 +43,7 @@ class Context
 {
   public:
     Context() = delete;
-    Context(std::size_t rank, std::size_t size);
+    Context(const Runner& runner, IEngine& engine, std::size_t rank);
     virtual ~Context() = default;
 
     EngineType execution_context() const;
@@ -53,6 +55,8 @@ class Context
     void unlock();
     void barrier();
     void yield();
+
+    Future<void> launch_task(std::function<void()> task);
 
     const std::string& info() const;
 
@@ -69,7 +73,7 @@ class Context
     void set_exception(std::exception_ptr exception_ptr);
 
   protected:
-    void init(const Runner& runner);
+    void start();
     bool status() const;
     void finish();
     virtual void init_info(std::stringstream& ss);
@@ -79,7 +83,8 @@ class Context
     std::size_t m_size;
     std::string m_info{"Uninitialized Context"};
     std::exception_ptr m_exception_ptr{nullptr};
-    const Runner* m_runner{nullptr};
+    const Runner& m_runner;
+    IEngine& m_engine;
 
     virtual void do_lock()                          = 0;
     virtual void do_unlock()                        = 0;

--- a/cpp/mrc/include/mrc/runnable/context.hpp
+++ b/cpp/mrc/include/mrc/runnable/context.hpp
@@ -17,19 +17,20 @@
 
 #pragma once
 
-#include "mrc/types.hpp"
+#include "mrc/types.hpp"  // for Future
 
-#include <glog/logging.h>
+#include <glog/logging.h>  // for CHECK, COMPACT_GOOGLE_LOG_FATAL, LogMessag...
 
-#include <cstddef>
-#include <exception>
-#include <sstream>
-#include <string>
+#include <cstddef>     // for size_t
+#include <exception>   // for exception_ptr
+#include <functional>  // for function
+#include <sstream>     // for stringstream
+#include <string>      // for allocator, string
 
 namespace mrc::runnable {
 
-class Runner;
 class IEngine;
+class Runner;
 enum class EngineType;
 
 /**

--- a/cpp/mrc/include/mrc/runnable/context.hpp
+++ b/cpp/mrc/include/mrc/runnable/context.hpp
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "mrc/types.hpp"
+
 #include <glog/logging.h>
 
 #include <cstddef>
@@ -43,7 +44,7 @@ class Context
 {
   public:
     Context() = delete;
-    Context(const Runner& runner, IEngine& engine, std::size_t rank);
+    Context(const Runner& runner, IEngine& engine, std::size_t rank, std::size_t size);
     virtual ~Context() = default;
 
     EngineType execution_context() const;
@@ -56,7 +57,7 @@ class Context
     void barrier();
     void yield();
 
-    Future<void> launch_task(std::function<void()> task);
+    Future<void> launch_fiber(std::function<void()> task);
 
     const std::string& info() const;
 

--- a/cpp/mrc/include/mrc/runnable/detail/type_traits.hpp
+++ b/cpp/mrc/include/mrc/runnable/detail/type_traits.hpp
@@ -85,7 +85,7 @@ static auto unwrap_context(l4_concept c, ThreadContext<T>& t)
     return std::make_pair(self<ctx_thread>{}, self<T>{});
 }
 
-template<typename T>
+template <typename T>
 static auto unwrap_context(l2_concept c, T& t)
 {
     return std::make_pair(self<T>{}, self<T>{});

--- a/cpp/mrc/include/mrc/runnable/detail/type_traits.hpp
+++ b/cpp/mrc/include/mrc/runnable/detail/type_traits.hpp
@@ -85,16 +85,10 @@ static auto unwrap_context(l4_concept c, ThreadContext<T>& t)
     return std::make_pair(self<ctx_thread>{}, self<T>{});
 }
 
-static auto unwrap_context(l2_concept c, Context& t)
+template<typename T>
+static auto unwrap_context(l2_concept c, T& t)
 {
-    return std::make_pair(self<Context>{}, self<Context>{});
-}
-
-template <typename T>
-static error unwrap_context(error e, T& t)
-{
-    static_assert(invalid_concept<T>::error, "object is not a Context");
-    return {};
+    return std::make_pair(self<T>{}, self<T>{});
 }
 
 template <typename T>

--- a/cpp/mrc/include/mrc/runnable/engine.hpp
+++ b/cpp/mrc/include/mrc/runnable/engine.hpp
@@ -22,6 +22,7 @@
 #include "mrc/core/fiber_meta_data.hpp"
 #include "mrc/core/fiber_pool.hpp"
 #include "mrc/core/task_queue.hpp"
+#include "mrc/runnable/context.hpp"
 #include "mrc/runnable/launch_options.hpp"
 #include "mrc/types.hpp"
 
@@ -54,6 +55,7 @@ class IEngine
     virtual Future<void> launch_task(std::function<void()> task) = 0;
 
     friend Runner;
+    friend Context;
 };
 
 /**

--- a/cpp/mrc/include/mrc/runnable/launch_control.hpp
+++ b/cpp/mrc/include/mrc/runnable/launch_control.hpp
@@ -338,7 +338,8 @@ class LaunchControl final
         auto resources = std::make_shared<typename WrappedContextT::resource_t>(size);
         for (std::size_t i = 0; i < size; ++i)
         {
-            contexts.push_back(std::make_shared<WrappedContextT>(resources, runner, *engines.launchers()[i], i, args...));
+            contexts.push_back(
+                std::make_shared<WrappedContextT>(resources, runner, *engines.launchers()[i], i, size, args...));
         }
         return std::move(contexts);
     }

--- a/cpp/mrc/include/mrc/runnable/launch_control.hpp
+++ b/cpp/mrc/include/mrc/runnable/launch_control.hpp
@@ -103,6 +103,9 @@ class LaunchControl final
         // engines are out way of running some task on the specified backend
         std::shared_ptr<IEngines> engines = build_engines(options);
 
+        // create runner
+        auto runner = runnable::make_runner(std::move(runnable));
+
         // make contexts
         std::vector<std::shared_ptr<Context>> contexts;
         if constexpr (is_fiber_runnable_v<RunnableT>)
@@ -113,6 +116,7 @@ class LaunchControl final
                                                                                                      "ThreadEngine";
 
             contexts = make_contexts<FiberContext<ContextWrapperT<context_t>>>(
+                *runner,
                 *engines,
                 std::forward<ContextArgsT>(context_args)...);
         }
@@ -123,6 +127,7 @@ class LaunchControl final
                                                                                                       "to be run on a "
                                                                                                       "FiberEngine";
             contexts = make_contexts<ThreadContext<ContextWrapperT<context_t>>>(
+                *runner,
                 *engines,
                 std::forward<ContextArgsT>(context_args)...);
         }
@@ -132,12 +137,14 @@ class LaunchControl final
             if (backend == EngineType::Fiber)
             {
                 contexts = make_contexts<FiberContext<ContextWrapperT<context_t>>>(
+                    *runner,
                     *engines,
                     std::forward<ContextArgsT>(context_args)...);
             }
             else if (backend == EngineType::Thread)
             {
                 contexts = make_contexts<ThreadContext<ContextWrapperT<context_t>>>(
+                    *runner,
                     *engines,
                     std::forward<ContextArgsT>(context_args)...);
             }
@@ -146,9 +153,6 @@ class LaunchControl final
                 LOG(FATAL) << "Unsupported EngineType";
             }
         }
-
-        // create runner
-        auto runner = runnable::make_runner(std::move(runnable));
 
         // construct the launcher
         return std::make_unique<Launcher>(std::move(runner), std::move(contexts), std::move(engines));
@@ -204,6 +208,9 @@ class LaunchControl final
         // engines are out way of running some task on the specified backend
         std::shared_ptr<IEngines> engines = build_engines(options);
 
+        // create runner
+        auto runner = runnable::make_runner(std::move(runnable));
+
         // make contexts
         std::vector<std::shared_ptr<Context>> contexts;
         if constexpr (is_fiber_runnable_v<RunnableT>)
@@ -212,7 +219,7 @@ class LaunchControl final
                                                                                                      "FiberRunnable to "
                                                                                                      "be run on a "
                                                                                                      "ThreadEngine";
-            contexts = make_contexts<context_t>(*engines, std::forward<ContextArgsT>(context_args)...);
+            contexts = make_contexts<context_t>(*runner, *engines, std::forward<ContextArgsT>(context_args)...);
         }
         else if constexpr (is_thread_context_v<RunnableT>)
         {
@@ -220,19 +227,21 @@ class LaunchControl final
                                                                                                       "ThreadRunnable "
                                                                                                       "to be run on a "
                                                                                                       "FiberEngine";
-            contexts = make_contexts<context_t>(*engines, std::forward<ContextArgsT>(context_args)...);
+            contexts = make_contexts<context_t>(*runner, *engines, std::forward<ContextArgsT>(context_args)...);
         }
         else
         {
             auto backend = get_engine_factory(options.engine_factory_name).backend();
             if (backend == EngineType::Fiber)
             {
-                contexts = make_contexts<FiberContext<context_t>>(*engines,
+                contexts = make_contexts<FiberContext<context_t>>(*runner,
+                                                                  *engines,
                                                                   std::forward<ContextArgsT>(context_args)...);
             }
             else if (backend == EngineType::Thread)
             {
-                contexts = make_contexts<ThreadContext<context_t>>(*engines,
+                contexts = make_contexts<ThreadContext<context_t>>(*runner,
+                                                                   *engines,
                                                                    std::forward<ContextArgsT>(context_args)...);
             }
             else
@@ -240,9 +249,6 @@ class LaunchControl final
                 LOG(FATAL) << "Unsupported EngineType";
             }
         }
-
-        // create runner
-        auto runner = runnable::make_runner(std::move(runnable));
 
         // construct the launcher
         return std::make_unique<Launcher>(std::move(runner), std::move(contexts), std::move(engines));
@@ -325,14 +331,14 @@ class LaunchControl final
      * @return auto
      */
     template <typename WrappedContextT, typename... ArgsT>
-    auto make_contexts(const IEngines& engines, ArgsT&&... args)
+    auto make_contexts(const Runner& runner, const IEngines& engines, ArgsT&&... args)
     {
         const auto size = engines.size();
         std::vector<std::shared_ptr<Context>> contexts;
         auto resources = std::make_shared<typename WrappedContextT::resource_t>(size);
         for (std::size_t i = 0; i < size; ++i)
         {
-            contexts.push_back(std::make_shared<WrappedContextT>(resources, i, size, args...));
+            contexts.push_back(std::make_shared<WrappedContextT>(resources, runner, *engines.launchers()[i], i, args...));
         }
         return std::move(contexts);
     }

--- a/cpp/mrc/include/mrc/runnable/runner.hpp
+++ b/cpp/mrc/include/mrc/runnable/runner.hpp
@@ -248,7 +248,7 @@ class SpecializedRunner : public Runner
         auto resources = std::make_shared<typename WrappedContextT::resource_t>(size);
         for (std::size_t i = 0; i < size; ++i)
         {
-            contexts.push_back(std::make_shared<WrappedContextT>(resources, i, size, std::forward<ArgsT>(args)...));
+            contexts.push_back(std::make_shared<WrappedContextT>(resources, i, std::forward<ArgsT>(args)...));
         }
         return std::move(contexts);
     }

--- a/cpp/mrc/include/mrc/segment/builder.hpp
+++ b/cpp/mrc/include/mrc/segment/builder.hpp
@@ -278,6 +278,9 @@ class IBuilder
               typename... ArgsT>
     auto make_node(std::string name, ArgsT&&... ops);
 
+    template<typename NodeTypeT, typename... ArgsT>
+    auto make_node_explicit(std::string name, ArgsT&&... ops);
+
     /**
      * Creates and returns an instance of a node component with the specified type, name and arguments.
      * @tparam SinkTypeT The sink type of the node component to be created.
@@ -434,6 +437,12 @@ template <typename SinkTypeT,
 auto IBuilder::make_node(std::string name, ArgsT&&... ops)
 {
     return construct_object<NodeTypeT<SinkTypeT, SourceTypeT>>(name, std::forward<ArgsT>(ops)...);
+}
+
+template<typename NodeTypeT, typename... ArgsT>
+auto IBuilder::make_node_explicit(std::string name, ArgsT&&... ops)
+{
+    return construct_object<NodeTypeT>(name, std::forward<ArgsT>(ops)...);
 }
 
 template <typename SinkTypeT, typename SourceTypeT, template <class, class> class NodeTypeT, typename... ArgsT>

--- a/cpp/mrc/include/mrc/segment/builder.hpp
+++ b/cpp/mrc/include/mrc/segment/builder.hpp
@@ -278,7 +278,7 @@ class IBuilder
               typename... ArgsT>
     auto make_node(std::string name, ArgsT&&... ops);
 
-    template<typename NodeTypeT, typename... ArgsT>
+    template <typename NodeTypeT, typename... ArgsT>
     auto make_node_explicit(std::string name, ArgsT&&... ops);
 
     /**
@@ -439,7 +439,7 @@ auto IBuilder::make_node(std::string name, ArgsT&&... ops)
     return construct_object<NodeTypeT<SinkTypeT, SourceTypeT>>(name, std::forward<ArgsT>(ops)...);
 }
 
-template<typename NodeTypeT, typename... ArgsT>
+template <typename NodeTypeT, typename... ArgsT>
 auto IBuilder::make_node_explicit(std::string name, ArgsT&&... ops)
 {
     return construct_object<NodeTypeT>(name, std::forward<ArgsT>(ops)...);

--- a/cpp/mrc/include/mrc/segment/context.hpp
+++ b/cpp/mrc/include/mrc/segment/context.hpp
@@ -28,8 +28,8 @@ class Context : public ContextT
 {
   public:
     template <typename... ArgsT>
-    Context(std::size_t rank, std::size_t size, std::string name, ArgsT&&... args) :
-      ContextT(std::move(rank), std::move(size), std::forward<ArgsT>(args)...),
+    Context(const mrc::runnable::Runner& runner, mrc::runnable::IEngine& engine, std::size_t rank, std::string name, ArgsT&&... args) :
+      ContextT(runner, engine, std::move(rank), std::forward<ArgsT>(args)...),
       m_name(std::move(name))
     {
         static_assert(std::is_base_of_v<runnable::Context, ContextT>, "ContextT must derive from Context");

--- a/cpp/mrc/include/mrc/segment/context.hpp
+++ b/cpp/mrc/include/mrc/segment/context.hpp
@@ -28,8 +28,13 @@ class Context : public ContextT
 {
   public:
     template <typename... ArgsT>
-    Context(const mrc::runnable::Runner& runner, mrc::runnable::IEngine& engine, std::size_t rank, std::string name, ArgsT&&... args) :
-      ContextT(runner, engine, std::move(rank), std::forward<ArgsT>(args)...),
+    Context(const mrc::runnable::Runner& runner,
+            mrc::runnable::IEngine& engine,
+            std::size_t rank,
+            std::size_t size,
+            std::string name,
+            ArgsT&&... args) :
+      ContextT(runner, engine, std::move(rank), std::move(size), std::forward<ArgsT>(args)...),
       m_name(std::move(name))
     {
         static_assert(std::is_base_of_v<runnable::Context, ContextT>, "ContextT must derive from Context");

--- a/cpp/mrc/src/internal/runnable/engine.cpp
+++ b/cpp/mrc/src/internal/runnable/engine.cpp
@@ -17,13 +17,10 @@
 
 #include "internal/runnable/engine.hpp"
 
-#include "mrc/types.hpp"
+#include "mrc/types.hpp"  // for Future
 
-#include <glog/logging.h>
-
-#include <mutex>
-#include <ostream>
-#include <utility>
+#include <mutex>    // for mutex, lock_guard
+#include <utility>  // for move
 
 namespace mrc::runnable {
 

--- a/cpp/mrc/src/internal/runnable/engine.cpp
+++ b/cpp/mrc/src/internal/runnable/engine.cpp
@@ -30,10 +30,6 @@ namespace mrc::runnable {
 Future<void> Engine::launch_task(std::function<void()> task)
 {
     std::lock_guard<decltype(m_mutex)> lock(m_mutex);
-    if (m_launched)
-    {
-        LOG(FATAL) << "detected attempted reuse of a runnable::Engine; this is a fatal error";
-    }
     m_launched = true;
     return do_launch_task(std::move(task));
 }

--- a/cpp/mrc/src/public/runnable/context.cpp
+++ b/cpp/mrc/src/public/runnable/context.cpp
@@ -47,11 +47,11 @@ struct FiberLocalContext
 
 }  // namespace
 
-Context::Context(const Runner& runner, IEngine& engine, std::size_t rank) :
+Context::Context(const Runner& runner, IEngine& engine, std::size_t rank, std::size_t size) :
   m_runner(runner),
   m_engine(engine),
   m_rank(rank),
-  m_size(runner.instances().size())
+  m_size(size)
 {}
 
 EngineType Context::execution_context() const
@@ -98,13 +98,12 @@ void Context::yield()
     do_yield();
 }
 
-Future<void> Context::launch_task(std::function<void()> task)
+Future<void> Context::launch_fiber(std::function<void()> task)
 {
-    boost::fibers::async([this, task = std::move(task)]() {
+    return boost::fibers::async([this, task]() {
         auto& fiber_local = FiberLocalContext::get();
         fiber_local.reset(new FiberLocalContext());
         fiber_local->m_context = this;
-
         try
         {
             task();

--- a/cpp/mrc/src/public/runnable/context.cpp
+++ b/cpp/mrc/src/public/runnable/context.cpp
@@ -17,16 +17,17 @@
 
 #include "mrc/runnable/context.hpp"
 
-#include "mrc/runnable/runner.hpp"
+#include "mrc/runnable/runner.hpp"  // for Runner
 
-#include <boost/fiber/fss.hpp>
-#include <glog/logging.h>
+#include <boost/fiber/fss.hpp>           // for fiber_specific_ptr
+#include <boost/fiber/future/async.hpp>  // for async
+#include <glog/logging.h>                // for COMPACT_GOOGLE_LOG_FATAL
 
-#include <cstddef>
-#include <exception>
-#include <sstream>
-#include <string>
-#include <utility>
+#include <cstddef>    // for size_t
+#include <exception>  // for exception_ptr, current_excep...
+#include <sstream>    // for operator<<, basic_ostream
+#include <string>     // for char_traits, operator<<, string
+#include <utility>    // for move
 
 namespace mrc::runnable {
 

--- a/cpp/mrc/src/public/runnable/runner.cpp
+++ b/cpp/mrc/src/public/runnable/runner.cpp
@@ -130,7 +130,7 @@ void Runner::enqueue(std::shared_ptr<IEngines> launcher, std::vector<std::shared
         auto engine  = instance.m_engine;
 
         auto f = engine->launch_task([this, context, &instance] {
-            context->init(*this);
+            context->start();
             update_state(context->rank(), State::Running);
             instance.m_live_promise.set_value();
             m_runnable->main(*context);

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -8,6 +8,7 @@ files:
     includes:
       - empty
       - build_cpp
+      - dev_cpp
       - cudatoolkit
 
 channels:
@@ -46,6 +47,13 @@ dependencies:
           - scikit-build>=0.17
           - pybind11-stubgen=0.10
           - python=3.10
+
+  dev_cpp:
+    common:
+      - output_types: [conda]
+        packages:
+          - clangdev=14
+
   cudatoolkit:
     specific:
       - output_types: [conda]

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -52,7 +52,7 @@ dependencies:
     common:
       - output_types: [conda]
         packages:
-          - clangdev=14
+          - clangdev=16
 
   cudatoolkit:
     specific:

--- a/python/mrc/_pymrc/include/pymrc/executor.hpp
+++ b/python/mrc/_pymrc/include/pymrc/executor.hpp
@@ -32,6 +32,9 @@ class IExecutor;
 }
 
 namespace mrc::pymrc {
+
+std::function<void()> create_gil_initializer();
+
 class Pipeline;
 
 // Export everything in the mrc::pymrc namespace by default since we compile with -fvisibility=hidden

--- a/python/mrc/_pymrc/include/pymrc/node.hpp
+++ b/python/mrc/_pymrc/include/pymrc/node.hpp
@@ -343,7 +343,7 @@ class PythonNodeContext : public mrc::runnable::Context
     PyHolder get_asyncio_event_loop();
 
   private:
-    // this was intended to be a thread-specific-pointer, but I couldn't get boost::thread to link.
+    // TODO(cwharris): this should be a thread-specific pointer,
     std::unique_ptr<PythonNodeLoopHandle> m_loop_handle;
 };
 

--- a/python/mrc/_pymrc/include/pymrc/node.hpp
+++ b/python/mrc/_pymrc/include/pymrc/node.hpp
@@ -334,7 +334,10 @@ class PythonNodeLoopHandle
 class PythonNodeContext : public mrc::runnable::Context
 {
   public:
-    PythonNodeContext(const mrc::runnable::Runner& runner, mrc::runnable::IEngine& engine, std::size_t rank);
+    PythonNodeContext(const mrc::runnable::Runner& runner,
+                      mrc::runnable::IEngine& engine,
+                      std::size_t rank,
+                      std::size_t size);
     ~PythonNodeContext() override;
 
     PyHolder get_asyncio_event_loop();

--- a/python/mrc/_pymrc/include/pymrc/node.hpp
+++ b/python/mrc/_pymrc/include/pymrc/node.hpp
@@ -33,6 +33,7 @@
 #include "mrc/node/rx_sink.hpp"
 #include "mrc/node/rx_source.hpp"
 #include "mrc/runnable/context.hpp"
+#include "mrc/runnable/engine.hpp"
 
 #include <pybind11/cast.h>
 #include <pybind11/gil.h>
@@ -333,7 +334,7 @@ class PythonNodeLoopHandle
 class PythonNodeContext : public mrc::runnable::Context
 {
   public:
-    PythonNodeContext(std::size_t rank, std::size_t size);
+    PythonNodeContext(const mrc::runnable::Runner& runner, mrc::runnable::IEngine& engine, std::size_t rank);
     ~PythonNodeContext() override;
 
     PyHolder get_asyncio_event_loop();

--- a/python/mrc/_pymrc/include/pymrc/node.hpp
+++ b/python/mrc/_pymrc/include/pymrc/node.hpp
@@ -33,17 +33,19 @@
 #include "mrc/node/rx_sink.hpp"
 #include "mrc/node/rx_source.hpp"
 #include "mrc/runnable/context.hpp"
-#include "mrc/runnable/engine.hpp"
+#include "mrc/runnable/runner.hpp"  // for Runner
 
 #include <pybind11/cast.h>
 #include <pybind11/gil.h>
 #include <pybind11/pytypes.h>
 #include <rxcpp/rx.hpp>
+#include <stdint.h>  // for uint32_t
 
 #include <atomic>
 #include <cstddef>
 #include <functional>
 #include <memory>
+#include <thread>  // for thread
 #include <utility>
 
 // Avoid forward declaring template specialization base classes
@@ -51,6 +53,12 @@
 // IWYU pragma: no_forward_declare mrc::edge::ConvertingEdgeWritable
 
 namespace mrc {
+
+namespace runnable {
+
+class IEngine;
+
+}
 
 namespace edge {
 

--- a/python/mrc/_pymrc/include/pymrc/node.hpp
+++ b/python/mrc/_pymrc/include/pymrc/node.hpp
@@ -39,6 +39,7 @@
 #include <pybind11/pytypes.h>
 #include <rxcpp/rx.hpp>
 
+#include <cstddef>
 #include <functional>
 #include <memory>
 #include <utility>
@@ -310,14 +311,21 @@ class PythonSinkComponent : public node::RxSinkComponent<InputT>,
     using base_t::base_t;
 };
 
-template <typename InputT, typename OutputT, typename ContextT = mrc::runnable::Context>
-class PythonNode : public node::RxNode<InputT, OutputT, ContextT>,
+class PythonNodeContext : public mrc::runnable::Context
+{
+  public:
+    PythonNodeContext(std::size_t rank, std::size_t size);
+    ~PythonNodeContext() override;
+};
+
+template <typename InputT, typename OutputT>
+class PythonNode : public node::RxNode<InputT, OutputT, PythonNodeContext>,
                    public pymrc::AutoRegSourceAdapter<OutputT>,
                    public pymrc::AutoRegSinkAdapter<InputT>,
                    public pymrc::AutoRegIngressPort<OutputT>,
                    public pymrc::AutoRegEgressPort<InputT>
 {
-    using base_t = node::RxNode<InputT, OutputT>;
+    using base_t = node::RxNode<InputT, OutputT, PythonNodeContext>;
 
   public:
     using typename base_t::stream_fn_t;

--- a/python/mrc/_pymrc/include/pymrc/operators.hpp
+++ b/python/mrc/_pymrc/include/pymrc/operators.hpp
@@ -60,6 +60,7 @@ class OperatorsProxy
     static PythonOperator build(PyFuncHolder<void(const PyObjectObservable& obs, PyObjectSubscriber& sub)> build_fn);
     static PythonOperator filter(PyFuncHolder<bool(pybind11::object x)> filter_fn);
     static PythonOperator flatten();
+    static PythonOperator flatmap(OnDataFunction flatmap_fn);
     static PythonOperator map(OnDataFunction map_fn);
     static PythonOperator on_completed(PyFuncHolder<std::optional<pybind11::object>()> finally_fn);
     static PythonOperator pairwise();

--- a/python/mrc/_pymrc/include/pymrc/operators.hpp
+++ b/python/mrc/_pymrc/include/pymrc/operators.hpp
@@ -60,7 +60,7 @@ class OperatorsProxy
     static PythonOperator build(PyFuncHolder<void(const PyObjectObservable& obs, PyObjectSubscriber& sub)> build_fn);
     static PythonOperator filter(PyFuncHolder<bool(pybind11::object x)> filter_fn);
     static PythonOperator flatten();
-    static PythonOperator flatmap(OnDataFunction flatmap_fn);
+    static PythonOperator flatmap(PyFuncHolder<PyObjectHolder(pybind11::object)> flatmap_fn);
     static PythonOperator map(OnDataFunction map_fn);
     static PythonOperator on_completed(PyFuncHolder<std::optional<pybind11::object>()> finally_fn);
     static PythonOperator pairwise();

--- a/python/mrc/_pymrc/include/pymrc/operators.hpp
+++ b/python/mrc/_pymrc/include/pymrc/operators.hpp
@@ -61,14 +61,15 @@ class AsyncOperatorHandler
     ~AsyncOperatorHandler();
 
     void process_async_generator(PyObjectHolder asyncgen);
-    void join();
+    void wait_completed();
+    void wait_cancel();
 
   private:
     PyObjectSubscriber m_sink;
     pybind11::module_ m_asyncio;
     PyHolder m_loop;
     std::thread m_loop_thread;
-    std::atomic<bool> m_loop_ct = false;
+    std::atomic<bool> m_loop_ct        = false;
     std::atomic<int32_t> m_outstanding = 0;
 };
 

--- a/python/mrc/_pymrc/include/pymrc/operators.hpp
+++ b/python/mrc/_pymrc/include/pymrc/operators.hpp
@@ -19,6 +19,9 @@
 
 #include "pymrc/types.hpp"
 
+#include <boost/fiber/future/promise.hpp>
+
+#include <future>
 #include <optional>
 #include <string>
 
@@ -57,20 +60,16 @@ class OperatorProxy
 class AsyncOperatorHandler
 {
   public:
-    AsyncOperatorHandler(PyObjectSubscriber sink);
+    AsyncOperatorHandler();
     ~AsyncOperatorHandler();
 
-    void process_async_generator(PyObjectHolder asyncgen);
-    void wait_completed();
-    void wait_cancel();
+    boost::fibers::future<PyObjectHolder> process_async_generator(PyObjectHolder asyncgen);
 
   private:
-    PyObjectSubscriber m_sink;
     pybind11::module_ m_asyncio;
     PyHolder m_loop;
     std::thread m_loop_thread;
-    std::atomic<bool> m_loop_ct        = false;
-    std::atomic<int32_t> m_outstanding = 0;
+    std::atomic<bool> m_loop_ct = false;
 };
 
 class OperatorsProxy
@@ -79,7 +78,7 @@ class OperatorsProxy
     static PythonOperator build(PyFuncHolder<void(const PyObjectObservable& obs, PyObjectSubscriber& sub)> build_fn);
     static PythonOperator filter(PyFuncHolder<bool(pybind11::object x)> filter_fn);
     static PythonOperator flatten();
-    static PythonOperator flatmap_async(PyFuncHolder<PyObjectHolder(pybind11::object)> flatmap_fn);
+    static PythonOperator concat_map_async(PyFuncHolder<PyObjectHolder(pybind11::object)> flatmap_fn);
     static PythonOperator map(OnDataFunction map_fn);
     static PythonOperator on_completed(PyFuncHolder<std::optional<pybind11::object>()> finally_fn);
     static PythonOperator pairwise();

--- a/python/mrc/_pymrc/include/pymrc/operators.hpp
+++ b/python/mrc/_pymrc/include/pymrc/operators.hpp
@@ -63,13 +63,14 @@ class AsyncOperatorHandler
     AsyncOperatorHandler();
     ~AsyncOperatorHandler() = default;
 
+    void process_async_task(PyObjectHolder task, PyObjectSubscriber sink);
     void process_async_generator(PyObjectHolder asyncgen, PyObjectSubscriber sink);
 
     void wait_completed() const;
     void wait_error();
 
   private:
-    boost::fibers::future<PyObjectHolder> future_from_async_generator(PyObjectHolder asyncgen);
+    boost::fibers::future<PyObjectHolder> future_from_async_task(PyObjectHolder task);
     pybind11::module_ m_asyncio;
     uint32_t m_outstanding = 0;
     bool m_cancelled       = false;
@@ -82,6 +83,7 @@ class OperatorsProxy
     static PythonOperator filter(PyFuncHolder<bool(pybind11::object x)> filter_fn);
     static PythonOperator flatten();
     static PythonOperator flat_map_async(PyFuncHolder<PyObjectHolder(pybind11::object)> flatmap_fn);
+    static PythonOperator map_async(PyFuncHolder<PyObjectHolder(pybind11::object)> flatmap_fn);
     static PythonOperator map(OnDataFunction map_fn);
     static PythonOperator on_completed(PyFuncHolder<std::optional<pybind11::object>()> finally_fn);
     static PythonOperator pairwise();

--- a/python/mrc/_pymrc/include/pymrc/operators.hpp
+++ b/python/mrc/_pymrc/include/pymrc/operators.hpp
@@ -54,6 +54,24 @@ class OperatorProxy
     static std::string get_name(PythonOperator& self);
 };
 
+class AsyncOperatorHandler
+{
+  public:
+    AsyncOperatorHandler(PyObjectSubscriber sink);
+    ~AsyncOperatorHandler();
+
+    void process_async_generator(PyObjectHolder asyncgen);
+    void join();
+
+  private:
+    PyObjectSubscriber m_sink;
+    pybind11::module_ m_asyncio;
+    PyHolder m_loop;
+    std::thread m_loop_thread;
+    std::atomic<bool> m_loop_ct = false;
+    std::atomic<int32_t> m_outstanding = 0;
+};
+
 class OperatorsProxy
 {
   public:

--- a/python/mrc/_pymrc/include/pymrc/operators.hpp
+++ b/python/mrc/_pymrc/include/pymrc/operators.hpp
@@ -63,10 +63,14 @@ class AsyncOperatorHandler
     AsyncOperatorHandler();
     ~AsyncOperatorHandler() = default;
 
-    boost::fibers::future<PyObjectHolder> process_async_generator(PyObjectHolder asyncgen);
+    void process_async_generator(PyObjectHolder asyncgen, PyObjectSubscriber sink);
+
+    void wait_completed() const;
 
   private:
+    boost::fibers::future<PyObjectHolder> future_from_async_generator(PyObjectHolder asyncgen);
     pybind11::module_ m_asyncio;
+    std::atomic<uint32_t> m_outstanding;
 };
 
 class OperatorsProxy
@@ -75,7 +79,7 @@ class OperatorsProxy
     static PythonOperator build(PyFuncHolder<void(const PyObjectObservable& obs, PyObjectSubscriber& sub)> build_fn);
     static PythonOperator filter(PyFuncHolder<bool(pybind11::object x)> filter_fn);
     static PythonOperator flatten();
-    static PythonOperator concat_map_async(PyFuncHolder<PyObjectHolder(pybind11::object)> flatmap_fn);
+    static PythonOperator flat_map_async(PyFuncHolder<PyObjectHolder(pybind11::object)> flatmap_fn);
     static PythonOperator map(OnDataFunction map_fn);
     static PythonOperator on_completed(PyFuncHolder<std::optional<pybind11::object>()> finally_fn);
     static PythonOperator pairwise();

--- a/python/mrc/_pymrc/include/pymrc/operators.hpp
+++ b/python/mrc/_pymrc/include/pymrc/operators.hpp
@@ -72,7 +72,7 @@ class AsyncOperatorHandler
     boost::fibers::future<PyObjectHolder> future_from_async_generator(PyObjectHolder asyncgen);
     pybind11::module_ m_asyncio;
     uint32_t m_outstanding = 0;
-    bool m_cancelled = false;
+    bool m_cancelled       = false;
 };
 
 class OperatorsProxy

--- a/python/mrc/_pymrc/include/pymrc/operators.hpp
+++ b/python/mrc/_pymrc/include/pymrc/operators.hpp
@@ -19,9 +19,9 @@
 
 #include "pymrc/types.hpp"
 
-#include <boost/fiber/future/promise.hpp>
+#include <pybind11/pybind11.h>  // for module_
 
-#include <future>
+#include <cstdint>  // for uint32_t
 #include <optional>
 #include <string>
 

--- a/python/mrc/_pymrc/include/pymrc/operators.hpp
+++ b/python/mrc/_pymrc/include/pymrc/operators.hpp
@@ -66,11 +66,13 @@ class AsyncOperatorHandler
     void process_async_generator(PyObjectHolder asyncgen, PyObjectSubscriber sink);
 
     void wait_completed() const;
+    void wait_error();
 
   private:
     boost::fibers::future<PyObjectHolder> future_from_async_generator(PyObjectHolder asyncgen);
     pybind11::module_ m_asyncio;
-    std::atomic<uint32_t> m_outstanding;
+    uint32_t m_outstanding = 0;
+    bool m_cancelled = false;
 };
 
 class OperatorsProxy

--- a/python/mrc/_pymrc/include/pymrc/operators.hpp
+++ b/python/mrc/_pymrc/include/pymrc/operators.hpp
@@ -61,15 +61,12 @@ class AsyncOperatorHandler
 {
   public:
     AsyncOperatorHandler();
-    ~AsyncOperatorHandler();
+    ~AsyncOperatorHandler() = default;
 
     boost::fibers::future<PyObjectHolder> process_async_generator(PyObjectHolder asyncgen);
 
   private:
     pybind11::module_ m_asyncio;
-    PyHolder m_loop;
-    std::thread m_loop_thread;
-    std::atomic<bool> m_loop_ct = false;
 };
 
 class OperatorsProxy

--- a/python/mrc/_pymrc/include/pymrc/operators.hpp
+++ b/python/mrc/_pymrc/include/pymrc/operators.hpp
@@ -78,7 +78,7 @@ class OperatorsProxy
     static PythonOperator build(PyFuncHolder<void(const PyObjectObservable& obs, PyObjectSubscriber& sub)> build_fn);
     static PythonOperator filter(PyFuncHolder<bool(pybind11::object x)> filter_fn);
     static PythonOperator flatten();
-    static PythonOperator flatmap(PyFuncHolder<PyObjectHolder(pybind11::object)> flatmap_fn);
+    static PythonOperator flatmap_async(PyFuncHolder<PyObjectHolder(pybind11::object)> flatmap_fn);
     static PythonOperator map(OnDataFunction map_fn);
     static PythonOperator on_completed(PyFuncHolder<std::optional<pybind11::object>()> finally_fn);
     static PythonOperator pairwise();

--- a/python/mrc/_pymrc/src/node.cpp
+++ b/python/mrc/_pymrc/src/node.cpp
@@ -80,8 +80,9 @@ PyHolder PythonNodeLoopHandle::get_asyncio_event_loop()
 
 PythonNodeContext::PythonNodeContext(const mrc::runnable::Runner& runner,
                                      mrc::runnable::IEngine& engine,
-                                     std::size_t rank) :
-  mrc::runnable::Context(runner, engine, rank)
+                                     std::size_t rank,
+                                     std::size_t size) :
+  mrc::runnable::Context(runner, engine, rank, size)
 {
     if (m_loop_handle == nullptr)
     {

--- a/python/mrc/_pymrc/src/node.cpp
+++ b/python/mrc/_pymrc/src/node.cpp
@@ -20,12 +20,20 @@
 #include "pymrc/executor.hpp"
 
 #include <pybind11/gil.h>
+#include <pybind11/pybind11.h>  // for module_
 
 #include <memory>
-#include <mutex>
 #include <thread>
 
-namespace mrc::pymrc {
+namespace mrc {
+
+namespace runnable {
+
+class IEngine;
+
+}
+
+namespace pymrc {
 
 PythonNodeLoopHandle::PythonNodeLoopHandle()
 {
@@ -110,4 +118,6 @@ PyHolder PythonNodeContext::get_asyncio_event_loop()
     return m_loop_handle->get_asyncio_event_loop();
 }
 
-}  // namespace mrc::pymrc
+}  // namespace pymrc
+
+}  // namespace mrc

--- a/python/mrc/_pymrc/src/node.cpp
+++ b/python/mrc/_pymrc/src/node.cpp
@@ -51,6 +51,11 @@ PythonNodeLoopHandle::PythonNodeLoopHandle()
 
             std::this_thread::yield();
         }
+
+        pybind11::gil_scoped_acquire acquire;
+        auto shutdown = loop.attr("shutdown_asyncgens")();
+        loop.attr("run_until_complete")(shutdown);
+        loop.attr("close")();
     });
 }
 

--- a/python/mrc/_pymrc/src/node.cpp
+++ b/python/mrc/_pymrc/src/node.cpp
@@ -78,7 +78,10 @@ PyHolder PythonNodeLoopHandle::get_asyncio_event_loop()
     return m_loop;
 }
 
-PythonNodeContext::PythonNodeContext(std::size_t rank, std::size_t size) : mrc::runnable::Context(rank, size)
+PythonNodeContext::PythonNodeContext(const mrc::runnable::Runner& runner,
+                                     mrc::runnable::IEngine& engine,
+                                     std::size_t rank) :
+  mrc::runnable::Context(runner, engine, rank)
 {
     if (m_loop_handle == nullptr)
     {

--- a/python/mrc/_pymrc/src/node.cpp
+++ b/python/mrc/_pymrc/src/node.cpp
@@ -17,4 +17,20 @@
 
 #include "pymrc/node.hpp"
 
-namespace mrc::pymrc {}  // namespace mrc::pymrc
+#include <pybind11/gil.h>
+
+namespace mrc::pymrc {
+
+PythonNodeContext::PythonNodeContext(std::size_t rank, std::size_t size) : mrc::runnable::Context(rank, size)
+{
+    pybind11::gil_scoped_acquire acquire;
+    pybind11::print("PythonNodeContext::ctor");
+}
+
+PythonNodeContext::~PythonNodeContext()
+{
+    pybind11::gil_scoped_acquire acquire;
+    pybind11::print("PythonNodeContext::dtor");
+}
+
+}  // namespace mrc::pymrc

--- a/python/mrc/_pymrc/src/operators.cpp
+++ b/python/mrc/_pymrc/src/operators.cpp
@@ -252,7 +252,7 @@ boost::fibers::future<PyObjectHolder> AsyncOperatorHandler::process_async_genera
 PythonOperator OperatorsProxy::concat_map_async(PyFuncHolder<PyObjectHolder(pybind11::object)> flatmap_fn)
 {
     //  Build and return the map operator
-    return {"flatten", [=](PyObjectObservable source) {
+    return {"concat_map_async", [=](PyObjectObservable source) {
                 return rxcpp::observable<>::create<PyHolder>([=](PyObjectSubscriber sink) {
                     auto async_handler = std::make_unique<AsyncOperatorHandler>();
                     source.subscribe(

--- a/python/mrc/_pymrc/src/operators.cpp
+++ b/python/mrc/_pymrc/src/operators.cpp
@@ -200,6 +200,11 @@ boost::fibers::future<PyObjectHolder> AsyncOperatorHandler::process_async_genera
 
     auto result_future = result->get_future();
 
+    // runnable::Context::get_runtime_context().launch_task([](){
+    //     pybind11::gil_scoped_acquire acquire;
+    //     pybind11::print("Hello from Context::launch_task");
+    // });
+
     future.attr("add_done_callback")(py::cpp_function([result = std::move(result)](py::object future) {
         try
         {

--- a/python/mrc/_pymrc/src/operators.cpp
+++ b/python/mrc/_pymrc/src/operators.cpp
@@ -23,7 +23,6 @@
 
 #include <glog/logging.h>
 #include <pybind11/cast.h>
-#include <pybind11/eval.h>
 #include <pybind11/functional.h>  // IWYU pragma: keep
 #include <pybind11/gil.h>
 #include <pybind11/pybind11.h>

--- a/python/mrc/_pymrc/src/operators.cpp
+++ b/python/mrc/_pymrc/src/operators.cpp
@@ -17,7 +17,6 @@
 
 #include "pymrc/operators.hpp"
 
-#include "pymrc/executor.hpp"
 #include "pymrc/node.hpp"
 #include "pymrc/types.hpp"
 #include "pymrc/utilities/acquire_gil.hpp"
@@ -26,10 +25,9 @@
 #include "mrc/core/utils.hpp"
 #include "mrc/runnable/context.hpp"
 
-#include <boost/fiber/context.hpp>
-#include <boost/fiber/fiber.hpp>
-#include <boost/fiber/future/async.hpp>
 #include <boost/fiber/future/future.hpp>
+#include <boost/fiber/future/future_status.hpp>
+#include <boost/fiber/future/promise.hpp>
 #include <boost/fiber/operations.hpp>
 #include <glog/logging.h>
 #include <pybind11/cast.h>
@@ -40,11 +38,9 @@
 #include <pyerrors.h>
 #include <rxcpp/rx.hpp>
 
+#include <chrono>
 #include <exception>
-#include <future>
-#include <sstream>
-#include <stdexcept>
-#include <thread>
+#include <memory>
 #include <tuple>
 #include <type_traits>
 #include <utility>

--- a/python/mrc/_pymrc/src/operators.cpp
+++ b/python/mrc/_pymrc/src/operators.cpp
@@ -255,10 +255,10 @@ void AsyncOperatorHandler::process_async_generator(PyObjectHolder asyncgen, PyOb
         {
             using namespace std::chrono_literals;
 
-            auto gil = std::make_unique<pybind11::gil_scoped_acquire>();
+            auto gil            = std::make_unique<pybind11::gil_scoped_acquire>();
             PyObjectHolder task = asyncgen.attr("__anext__")();
             gil.reset();
-            auto yielded    = this->future_from_async_task(task);
+            auto yielded = this->future_from_async_task(task);
 
             while (yielded.wait_for(0s) != boost::fibers::future_status::ready)
             {

--- a/python/mrc/_pymrc/src/segment.cpp
+++ b/python/mrc/_pymrc/src/segment.cpp
@@ -28,12 +28,9 @@
 #include "mrc/channel/status.hpp"
 #include "mrc/edge/edge_builder.hpp"
 #include "mrc/node/port_registry.hpp"
-#include "mrc/node/rx_sink_base.hpp"
-#include "mrc/node/rx_source_base.hpp"
 #include "mrc/runnable/context.hpp"
 #include "mrc/segment/builder.hpp"
 #include "mrc/segment/object.hpp"
-#include "mrc/types.hpp"
 
 #include <glog/logging.h>
 #include <pybind11/cast.h>
@@ -44,7 +41,6 @@
 #include <exception>
 #include <fstream>
 #include <functional>
-#include <future>
 #include <iterator>
 #include <map>
 #include <stdexcept>
@@ -52,7 +48,6 @@
 #include <type_traits>
 #include <typeindex>
 #include <utility>
-#include <vector>
 
 // IWYU thinks we need array for py::print
 // IWYU pragma: no_include <array>

--- a/python/mrc/_pymrc/src/segment.cpp
+++ b/python/mrc/_pymrc/src/segment.cpp
@@ -390,7 +390,8 @@ std::shared_ptr<mrc::segment::ObjectProperties> BuilderProxy::make_node(mrc::seg
                                                                         const std::string& name,
                                                                         pybind11::args operators)
 {
-    auto node = self.make_node<PyHolder, PyHolder, PythonNode>(name);
+    // auto node = self.make_node<PyHolder, PyHolder, PythonNode>(name);
+    auto node = self.make_node_explicit<PythonNode<PyHolder, PyHolder>>(name);
 
     node->object().make_stream(
         [operators = PyObjectHolder(std::move(operators))](const PyObjectObservable& input) -> PyObjectObservable {
@@ -412,7 +413,8 @@ std::shared_ptr<mrc::segment::ObjectProperties> BuilderProxy::make_node_full(
         "make_node_full(name, sub_fn) is deprecated and will be removed in a future version. Use "
         "make_node(name, mrc.core.operators.build(sub_fn)) instead.");
 
-    auto node = self.make_node<PyHolder, PyHolder, PythonNode>(name);
+    // auto node = self.make_node<PyHolder, PyHolder, PythonNode>(name);
+    auto node = self.make_node_explicit<PythonNode<PyHolder, PyHolder>>(name);
 
     node->object().make_stream([sub_fn](const PyObjectObservable& input) -> PyObjectObservable {
         return rxcpp::observable<>::create<PyHolder>([input, sub_fn](pymrc::PyObjectSubscriber output) {

--- a/python/mrc/core/operators.cpp
+++ b/python/mrc/core/operators.cpp
@@ -28,7 +28,6 @@
 #include <pybind11/pytypes.h>
 #include <pybind11/stl.h>  // IWYU pragma: keep
 
-#include <array>
 #include <sstream>
 
 namespace mrc::pymrc {

--- a/python/mrc/core/operators.cpp
+++ b/python/mrc/core/operators.cpp
@@ -56,6 +56,7 @@ PYBIND11_MODULE(operators, py_mod)
     py_mod.def("flatten", &OperatorsProxy::flatten);
     py_mod.def("flat_map_async", &OperatorsProxy::flat_map_async);
     py_mod.def("map", &OperatorsProxy::map);
+    py_mod.def("map_async", &OperatorsProxy::map_async);
     py_mod.def("on_completed", &OperatorsProxy::on_completed);
     py_mod.def("pairwise", &OperatorsProxy::pairwise);
     py_mod.def("to_list", &OperatorsProxy::to_list);

--- a/python/mrc/core/operators.cpp
+++ b/python/mrc/core/operators.cpp
@@ -55,7 +55,7 @@ PYBIND11_MODULE(operators, py_mod)
     py_mod.def("build", &OperatorsProxy::build);
     py_mod.def("filter", &OperatorsProxy::filter);
     py_mod.def("flatten", &OperatorsProxy::flatten);
-    py_mod.def("concat_map_async", &OperatorsProxy::concat_map_async);
+    py_mod.def("flat_map_async", &OperatorsProxy::flat_map_async);
     py_mod.def("map", &OperatorsProxy::map);
     py_mod.def("on_completed", &OperatorsProxy::on_completed);
     py_mod.def("pairwise", &OperatorsProxy::pairwise);

--- a/python/mrc/core/operators.cpp
+++ b/python/mrc/core/operators.cpp
@@ -55,7 +55,7 @@ PYBIND11_MODULE(operators, py_mod)
     py_mod.def("build", &OperatorsProxy::build);
     py_mod.def("filter", &OperatorsProxy::filter);
     py_mod.def("flatten", &OperatorsProxy::flatten);
-    py_mod.def("flatmap", &OperatorsProxy::flatmap);
+    py_mod.def("flatmap_async", &OperatorsProxy::flatmap_async);
     py_mod.def("map", &OperatorsProxy::map);
     py_mod.def("on_completed", &OperatorsProxy::on_completed);
     py_mod.def("pairwise", &OperatorsProxy::pairwise);

--- a/python/mrc/core/operators.cpp
+++ b/python/mrc/core/operators.cpp
@@ -55,6 +55,7 @@ PYBIND11_MODULE(operators, py_mod)
     py_mod.def("build", &OperatorsProxy::build);
     py_mod.def("filter", &OperatorsProxy::filter);
     py_mod.def("flatten", &OperatorsProxy::flatten);
+    py_mod.def("flatmap", &OperatorsProxy::flatmap);
     py_mod.def("map", &OperatorsProxy::map);
     py_mod.def("on_completed", &OperatorsProxy::on_completed);
     py_mod.def("pairwise", &OperatorsProxy::pairwise);

--- a/python/mrc/core/operators.cpp
+++ b/python/mrc/core/operators.cpp
@@ -55,7 +55,7 @@ PYBIND11_MODULE(operators, py_mod)
     py_mod.def("build", &OperatorsProxy::build);
     py_mod.def("filter", &OperatorsProxy::filter);
     py_mod.def("flatten", &OperatorsProxy::flatten);
-    py_mod.def("flatmap_async", &OperatorsProxy::flatmap_async);
+    py_mod.def("concat_map_async", &OperatorsProxy::concat_map_async);
     py_mod.def("map", &OperatorsProxy::map);
     py_mod.def("on_completed", &OperatorsProxy::on_completed);
     py_mod.def("pairwise", &OperatorsProxy::pairwise);

--- a/python/tests/test_operators.py
+++ b/python/tests/test_operators.py
@@ -130,15 +130,14 @@ def test_flatten(run_segment):
 
     assert actual == expected
 
+
 def test_flat_map_async(run_segment):
 
     input_data = [('a', 5), ('b', 1), ('c', 3)]
-    expected = [
-        ('a', 0), ('a', 1), ('a', 2), ('a', 3), ('a', 4), ('b', 0), ('c', 0), ('c', 1), ('c', 2)
-    ]
+    expected = [('a', 0), ('a', 1), ('a', 2), ('a', 3), ('a', 4), ('b', 0), ('c', 0), ('c', 1), ('c', 2)]
 
     import random
-    random.shuffle(input_data) # the output order is not dictated by the input order
+    random.shuffle(input_data)  # the output order is not dictated by the input order
 
     async def generate(value):
         name, count = value
@@ -161,6 +160,7 @@ def test_flat_map_async(run_segment):
     assert_sequential('a', actual)
     assert_sequential('b', actual)
     assert_sequential('c', actual)
+
 
 def test_filter(run_segment):
 

--- a/python/tests/test_operators.py
+++ b/python/tests/test_operators.py
@@ -130,6 +130,37 @@ def test_flatten(run_segment):
 
     assert actual == expected
 
+def test_flat_map_async(run_segment):
+
+    input_data = [('a', 5), ('b', 1), ('c', 3)]
+    expected = [
+        ('a', 0), ('a', 1), ('a', 2), ('a', 3), ('a', 4), ('b', 0), ('c', 0), ('c', 1), ('c', 2)
+    ]
+
+    import random
+    random.shuffle(input_data) # the output order is not dictated by the input order
+
+    async def generate(value):
+        name, count = value
+        for i in range(count):
+            yield (name, i)
+
+    def node_fn(input: mrc.Observable, output: mrc.Subscriber):
+        input.pipe(ops.flat_map_async(generate)).subscribe(output)
+
+    actual, raised_error = run_segment(input_data, node_fn)
+
+    assert set(actual) == set(expected)
+
+    def assert_sequential(name, actual):
+        # the output of individual generators must be sequential
+        import itertools
+        for i, (name, value) in zip(itertools.count(), filter(lambda pair: pair[0] == name, actual)):
+            assert i == value
+
+    assert_sequential('a', actual)
+    assert_sequential('b', actual)
+    assert_sequential('c', actual)
 
 def test_filter(run_segment):
 

--- a/python/tests/test_operators.py
+++ b/python/tests/test_operators.py
@@ -130,6 +130,22 @@ def test_flatten(run_segment):
 
     assert actual == expected
 
+def test_map_async(run_segment):
+
+    input_data = [0, 1, 2, 3]
+    expected = [0, 1, 4, 9]
+
+    async def square_async(value):
+        import asyncio
+        await asyncio.sleep(0)
+        return value * value
+
+    def node_fn(input: mrc.Observable, output: mrc.Subscriber):
+        input.pipe(ops.map_async(square_async)).subscribe(output)
+
+    actual, raised_error = run_segment(input_data, node_fn)
+
+    assert set(actual) == set(expected)
 
 def test_flat_map_async(run_segment):
 


### PR DESCRIPTION
## Description
Adds new operators `map_async` and `flat_map_async` that can handle Python Async Generators concurrently.

Closes #386 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
