### PR TITLE
Update PythonObjectCache to support get and pop operations, update utils to allow passing of cached python objects.

### DIFF
--- a/python/mrc/_pymrc/include/pymrc/utilities/object_cache.hpp
+++ b/python/mrc/_pymrc/include/pymrc/utilities/object_cache.hpp
@@ -79,6 +79,20 @@ class __attribute__((visibility("default"))) PythonObjectCache
     pybind11::object& get_module(const std::string& module_name);
 
     /**
+     * @brief Retrieve an object from the cache without removing it.
+     * @param object_id The ID of the object to retrieve.
+     * @return The cached object, or pybind11::none() if not found.
+     */
+    pybind11::object get(const std::string& object_id);
+
+    /**
+     * @brief Retrieve and remove an object from the cache.
+     * @param object_id The ID of the object to pop.
+     * @return The cached object, or pybind11::none() if not found.
+     */
+    pybind11::object pop(const std::string& object_id);
+
+    /**
      * @brief Add an arbitrary python object to the cache. If an entry with the same name exists it will be
      * overwritten.
      */

--- a/python/mrc/_pymrc/src/segment.cpp
+++ b/python/mrc/_pymrc/src/segment.cpp
@@ -396,7 +396,7 @@ std::shared_ptr<mrc::segment::ObjectProperties> BuilderProxy::make_node(mrc::seg
         [operators = PyObjectHolder(std::move(operators))](const PyObjectObservable& input) -> PyObjectObservable {
             AcquireGIL gil;
 
-            // Call the pipe function to convert all of the args to a new observable
+            // Call the pipe function to convert all the args to a new observable
             return ObservableProxy::pipe(&input, py::cast<py::args>(operators));
         });
 

--- a/python/mrc/_pymrc/src/utilities/object_cache.cpp
+++ b/python/mrc/_pymrc/src/utilities/object_cache.cpp
@@ -76,6 +76,26 @@ std::size_t PythonObjectCache::size()
     return m_object_cache.size();
 }
 
+/**
+ * @brief Retrieve an object from the cache without removing it.
+ * @param object_id The ID of the object to retrieve.
+ * @return The cached object, or pybind11::none() if not found.
+ */
+pybind11::object PythonObjectCache::get(const std::string& object_id)
+{
+    std::lock_guard<std::mutex> lock(s_cache_lock);
+
+    auto iter = m_object_cache.find(object_id);
+    if (iter != m_object_cache.end())
+    {
+        VLOG(1) << "Retrieving object: " << object_id;
+        return iter->second;
+    }
+
+    VLOG(1) << "Object not found in cache: " << object_id;
+    return pybind11::none();
+}
+
 pybind11::object PythonObjectCache::get_or_load(const std::string& object_id, std::function<pybind11::object()> loader)
 {
     std::lock_guard<std::mutex> lock(s_cache_lock);
@@ -91,6 +111,28 @@ pybind11::object PythonObjectCache::get_or_load(const std::string& object_id, st
     VLOG(1) << "Done caching loader object: " << object_id;
 
     return m_object_cache[object_id];
+}
+
+/**
+ * @brief Retrieve and remove an object from the cache.
+ * @param object_id The ID of the object to pop.
+ * @return The cached object, or pybind11::none() if not found.
+ */
+pybind11::object PythonObjectCache::pop(const std::string& object_id)
+{
+    std::lock_guard<std::mutex> lock(s_cache_lock);
+
+    auto iter = m_object_cache.find(object_id);
+    if (iter != m_object_cache.end())
+    {
+        VLOG(1) << "Popping and removing object: " << object_id;
+        pybind11::object obj = std::move(iter->second);
+        m_object_cache.erase(iter);
+        return obj;
+    }
+
+    VLOG(1) << "Object not found in cache to pop: " << object_id;
+    return pybind11::none();
 }
 
 pybind11::object& PythonObjectCache::get_module(const std::string& module_name)


### PR DESCRIPTION
## Description
Update PythonObjectCache to support get and pop operations, update utils to allow passing of cached python objects.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
