### PR TITLE
Revert adoption of Rapids 25.06

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2018-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2018-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -35,7 +35,7 @@ option(MRC_USE_CCACHE "Enable caching compilation results with ccache" OFF)
 option(MRC_USE_CLANG_TIDY "Enable running clang-tidy as part of the build process" OFF)
 option(MRC_USE_IWYU "Enable running include-what-you-use as part of the build process" OFF)
 
-set(MRC_RAPIDS_VERSION "25.06" CACHE STRING "Which version of RAPIDS to build for. Sets default versions for RAPIDS CMake and RMM.")
+set(MRC_RAPIDS_VERSION "25.02" CACHE STRING "Which version of RAPIDS to build for. Sets default versions for RAPIDS CMake and RMM.")
 
 set(MRC_CACHE_DIR "${CMAKE_SOURCE_DIR}/.cache" CACHE PATH "Directory to contain all CPM and CCache data")
 mark_as_advanced(MRC_CACHE_DIR)

--- a/ci/conda/recipes/libmrc/conda_build_config.yaml
+++ b/ci/conda/recipes/libmrc/conda_build_config.yaml
@@ -30,4 +30,4 @@ python:
 
 # Setup the dependencies to build with multiple versions of RAPIDS
 rapids_version: # Keep around compatibility with current version -2
-  - 25.06
+  - 25.02

--- a/ci/conda/recipes/libmrc/meta.yaml
+++ b/ci/conda/recipes/libmrc/meta.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ci/conda/recipes/libmrc/meta.yaml
+++ b/ci/conda/recipes/libmrc/meta.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -39,7 +39,7 @@ requirements:
     - {{ compiler("cuda") }}
     - {{ compiler("cxx") }}
     - ccache
-    - cmake =3.30
+    - cmake =3.27
     - libtool
     - ninja =1.11
     - numactl =2.0.18
@@ -54,7 +54,6 @@ requirements:
     - cuda-version {{ cuda_version }}.*
     - doxygen 1.10.0
     - glog>=0.7.1,<0.8
-    - icu >=73.2,<76.0a0  # Pin to version compatible with boost-cpp 1.84
     - libgrpc =1.62.2
     - gtest =1.14
     - libhwloc =2.9.2
@@ -62,7 +61,7 @@ requirements:
     - nlohmann_json =3.11
     - pybind11-abi # See: https://conda-forge.org/docs/maintainer/knowledge_base.html#pybind11-abi-constraints
     - pybind11-stubgen =0.10
-    - python {{ python }} *_cpython  # Use cpython builds with compatible icu
+    - python {{ python }}
     - scikit-build =0.17
     - ucx =1.15
     - versioneer =0.29
@@ -81,7 +80,7 @@ outputs:
         - {{ compiler("c") }}
         - {{ compiler("cuda") }}
         - {{ compiler("cxx") }}
-        - cmake =3.30
+        - cmake =3.27
         - numactl =2.0.18
         - sysroot_linux-64 >=2.28
       host:
@@ -89,7 +88,6 @@ outputs:
         - boost-cpp =1.84
         - cuda-version # Needed to allow pin_compatible to work
         - glog>=0.7.1,<0.8
-        - icu >=73.2,<76.0a0  # Pin to version compatible with boost-cpp 1.84
         - libgrpc =1.62.2
         - libhwloc =2.9.2
         - librmm {{ rapids_version }}
@@ -98,7 +96,6 @@ outputs:
       run:
         # Manually add any packages necessary for run that do not have run_exports. Keep sorted!
         - cuda-version {{ cuda_version }}.*
-        - icu >=73.2,<76.0a0  # Pin to version compatible with boost-cpp 1.84
         - nlohmann_json =3.11
         - ucx =1.15
         - cuda-cudart
@@ -125,7 +122,6 @@ outputs:
       host:
         # Only should need libmrc and python. Keep sorted!
         - {{ pin_subpackage('libmrc', exact=True) }}
-        - icu >=73.2,<76.0a0  # Pin to version compatible with boost-cpp 1.84
         - python {{ python }}
       run:
         - {{ pin_subpackage('libmrc', exact=True) }}
@@ -146,7 +142,6 @@ outputs:
         - pytest
         - pytest-asyncio
         - pytest-timeout
-        - icu >=73.2,<76.0a0  # Pin to version compatible with boost-cpp 1.84
         - cuml {{ rapids_version }}.* # Ensure we can install cuml. This can cause issues solving libabseil
 
 about:

--- a/ci/conda/recipes/run_conda_build.sh
+++ b/ci/conda/recipes/run_conda_build.sh
@@ -93,7 +93,7 @@ fi
 # Choose default variants
 if hasArg quick; then
    # For quick build, just do most recent version of rapids
-   CONDA_ARGS_ARRAY+=("--variants" "{rapids_version: 25.06}")
+   CONDA_ARGS_ARRAY+=("--variants" "{rapids_version: 25.02}")
 fi
 
 # And default channels (should match dependencies.yaml)

--- a/conda/environments/all_cuda-128_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-128_arch-aarch64.yaml
@@ -14,7 +14,7 @@ dependencies:
 - clang=16
 - clangdev=16
 - clangxx=16
-- cmake=3.30
+- cmake=3.27
 - codecov=2.1
 - cuda-cudart-dev=12.8
 - cuda-nvcc
@@ -33,7 +33,7 @@ dependencies:
 - libclang=16
 - libgrpc=1.62.2
 - libhwloc=2.9.2
-- librmm=25.06
+- librmm=24.10
 - libxml2=2.11.6
 - llvmdev=16
 - ninja=1.11

--- a/conda/environments/all_cuda-128_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-128_arch-x86_64.yaml
@@ -14,7 +14,7 @@ dependencies:
 - clang=16
 - clangdev=16
 - clangxx=16
-- cmake=3.30
+- cmake=3.27
 - codecov=2.1
 - cuda-cudart-dev=12.8
 - cuda-nvcc
@@ -34,7 +34,7 @@ dependencies:
 - libclang=16
 - libgrpc=1.62.2
 - libhwloc=2.9.2
-- librmm=25.06
+- librmm=24.10
 - libxml2=2.11.6
 - llvmdev=16
 - ninja=1.11

--- a/conda/environments/ci_cuda-128_arch-aarch64.yaml
+++ b/conda/environments/ci_cuda-128_arch-aarch64.yaml
@@ -9,7 +9,7 @@ dependencies:
 - benchmark=1.8.3
 - boost-cpp=1.84
 - ccache
-- cmake=3.30
+- cmake=3.27
 - codecov=2.1
 - cuda-cudart-dev=12.8
 - cuda-nvcc
@@ -24,7 +24,7 @@ dependencies:
 - gxx=12.1
 - libgrpc=1.62.2
 - libhwloc=2.9.2
-- librmm=25.06
+- librmm=24.10
 - libxml2=2.11.6
 - ninja=1.11
 - nlohmann_json=3.11

--- a/conda/environments/ci_cuda-128_arch-x86_64.yaml
+++ b/conda/environments/ci_cuda-128_arch-x86_64.yaml
@@ -9,7 +9,7 @@ dependencies:
 - benchmark=1.8.3
 - boost-cpp=1.84
 - ccache
-- cmake=3.30
+- cmake=3.27
 - codecov=2.1
 - cuda-cudart-dev=12.8
 - cuda-nvcc
@@ -25,7 +25,7 @@ dependencies:
 - include-what-you-use=0.20
 - libgrpc=1.62.2
 - libhwloc=2.9.2
-- librmm=25.06
+- librmm=24.10
 - libxml2=2.11.6
 - ninja=1.11
 - nlohmann_json=3.11

--- a/conda/environments/runtime_cuda-128_arch-x86_64.yaml
+++ b/conda/environments/runtime_cuda-128_arch-x86_64.yaml
@@ -14,6 +14,6 @@ dependencies:
 - libhwloc=2.9.2
 - nlohmann_json=3.11
 - python=3.12
-- rmm=25.06
+- rmm=24.10
 - ucx=1.15
 name: runtime_cuda-128_arch-x86_64

--- a/cpp/mrc/include/mrc/memory/resources/arena_resource.hpp
+++ b/cpp/mrc/include/mrc/memory/resources/arena_resource.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/cpp/mrc/include/mrc/memory/resources/arena_resource.hpp
+++ b/cpp/mrc/include/mrc/memory/resources/arena_resource.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,7 +22,6 @@
 
 #include <cuda_runtime_api.h>
 #include <glog/logging.h>
-#include <rmm/detail/aligned.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/logger.hpp>
 
@@ -136,7 +135,7 @@ class arena_resource final : public adaptor<Upstream>
             return nullptr;
         }
 
-        bytes         = rmm::align_up(bytes, rmm::CUDA_ALLOCATION_ALIGNMENT);
+        bytes         = detail::arena::align_up(bytes);
         auto& arena   = get_thread_arena();
         void* pointer = arena.allocate(bytes);
 
@@ -174,7 +173,7 @@ class arena_resource final : public adaptor<Upstream>
             return;
         }
 
-        bytes = rmm::align_up(bytes, rmm::CUDA_ALLOCATION_ALIGNMENT);
+        bytes = detail::arena::align_up(bytes);
         get_thread_arena().deallocate(ptr, bytes);
     }
 

--- a/cpp/mrc/include/mrc/memory/resources/detail/arena.hpp
+++ b/cpp/mrc/include/mrc/memory/resources/detail/arena.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -162,6 +162,28 @@ inline bool block_size_compare(block lhs, block rhs)
 }
 
 /**
+ * @brief Align up to the allocation alignment.
+ *
+ * @param[in] v value to align
+ * @return Return the aligned value
+ */
+constexpr std::size_t align_up(std::size_t value) noexcept
+{
+    return rmm::align_up(value, rmm::CUDA_ALLOCATION_ALIGNMENT);
+}
+
+/**
+ * @brief Align down to the allocation alignment.
+ *
+ * @param[in] v value to align
+ * @return Return the aligned value
+ */
+constexpr std::size_t align_down(std::size_t value) noexcept
+{
+    return rmm::align_down(value, rmm::CUDA_ALLOCATION_ALIGNMENT);
+}
+
+/**
  * @brief Get the first free block of at least `size` bytes.
  *
  * Address-ordered first-fit has shown to perform slightly better than best-fit when it comes to
@@ -296,11 +318,9 @@ class global_arena final
       maximum_size_{maximum_size}
     {
         RMM_EXPECTS(nullptr != upstream_mr_, "Unexpected null upstream pointer.");
-        RMM_EXPECTS(initial_size == default_initial_size ||
-                        initial_size == rmm::align_up(initial_size, rmm::CUDA_ALLOCATION_ALIGNMENT),
+        RMM_EXPECTS(initial_size == default_initial_size || initial_size == align_up(initial_size),
                     "Error, Initial arena size required to be a multiple of 256 bytes");
-        RMM_EXPECTS(maximum_size_ == default_maximum_size ||
-                        maximum_size_ == rmm::align_up(maximum_size_, rmm::CUDA_ALLOCATION_ALIGNMENT),
+        RMM_EXPECTS(maximum_size_ == default_maximum_size || maximum_size_ == align_up(maximum_size_),
                     "Error, Maximum arena size required to be a multiple of 256 bytes");
 
         if (initial_size == default_initial_size || maximum_size == default_maximum_size)
@@ -310,11 +330,11 @@ class global_arena final
             RMM_CUDA_TRY(cudaMemGetInfo(&free, &total));
             if (initial_size == default_initial_size)
             {
-                initial_size = rmm::align_up(std::min(free, total / 2), rmm::CUDA_ALLOCATION_ALIGNMENT);
+                initial_size = align_up(std::min(free, total / 2));
             }
             if (maximum_size_ == default_maximum_size)
             {
-                maximum_size_ = rmm::align_down(free, rmm::CUDA_ALLOCATION_ALIGNMENT) - reserved_size;
+                maximum_size_ = align_down(free) - reserved_size;
             }
         }
         RMM_EXPECTS(initial_size <= maximum_size_, "Initial arena size exceeds the maximum pool size!");

--- a/cpp/mrc/include/mrc/memory/resources/detail/arena.hpp
+++ b/cpp/mrc/include/mrc/memory/resources/detail/arena.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/cpp/mrc/include/mrc/memory/resources/detail/arena.hpp
+++ b/cpp/mrc/include/mrc/memory/resources/detail/arena.hpp
@@ -318,10 +318,13 @@ class global_arena final
       maximum_size_{maximum_size}
     {
         RMM_EXPECTS(nullptr != upstream_mr_, "Unexpected null upstream pointer.");
+
+        // NOLINTBEGIN
         RMM_EXPECTS(initial_size == default_initial_size || initial_size == align_up(initial_size),
                     "Error, Initial arena size required to be a multiple of 256 bytes");
         RMM_EXPECTS(maximum_size_ == default_maximum_size || maximum_size_ == align_up(maximum_size_),
                     "Error, Maximum arena size required to be a multiple of 256 bytes");
+        // NOLINTEND
 
         if (initial_size == default_initial_size || maximum_size == default_maximum_size)
         {

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -62,7 +62,7 @@ dependencies:
         packages:
           - boost-cpp=1.84
           - ccache
-          - cmake=3.30
+          - cmake=3.27
           - cuda-nvcc
           - cxx-compiler
           - glog>=0.7.1,<0.8
@@ -70,7 +70,7 @@ dependencies:
           - gxx=12.1
           - libgrpc=1.62.2
           - libhwloc=2.9.2
-          - librmm=25.06
+          - librmm=24.10
           - libxml2=2.11.6
           - ninja=1.11
           - nlohmann_json=3.11
@@ -188,5 +188,5 @@ dependencies:
         - libgrpc=1.62.2
         - libhwloc=2.9.2
         - nlohmann_json=3.11
-        - rmm=25.06
+        - rmm=24.10
         - ucx=1.15

--- a/python/mrc/_pymrc/tests/test_utils.cpp
+++ b/python/mrc/_pymrc/tests/test_utils.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,7 +23,6 @@
 
 #include <glog/logging.h>
 #include <gtest/gtest.h>
-#include <moduleobject.h>  // for PyModuleDef
 #include <nlohmann/json.hpp>
 #include <pybind11/cast.h>
 #include <pybind11/pybind11.h>

--- a/python/mrc/_pymrc/tests/test_utils.cpp
+++ b/python/mrc/_pymrc/tests/test_utils.cpp
@@ -23,8 +23,8 @@
 
 #include <glog/logging.h>
 #include <gtest/gtest.h>
-#include <nlohmann/json.hpp>
 #include <moduleobject.h>  // for PyModuleDef
+#include <nlohmann/json.hpp>
 #include <pybind11/cast.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/pytypes.h>

--- a/python/mrc/_pymrc/tests/test_utils.cpp
+++ b/python/mrc/_pymrc/tests/test_utils.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,6 +24,7 @@
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 #include <nlohmann/json.hpp>
+#include <moduleobject.h>  // for PyModuleDef
 #include <pybind11/cast.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/pytypes.h>

--- a/python/tests/test_coro.py
+++ b/python/tests/test_coro.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -122,7 +122,6 @@ async def test_python_cpp_async_exception():
     assert "c++" in str(ex.value)
 
 
-@pytest.mark.skip("Test is currently segfaulting issue #557")
 @pytest.mark.asyncio
 async def test_can_cancel_coroutine_from_python():
 

--- a/python/tests/test_coro.py
+++ b/python/tests/test_coro.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -122,6 +122,7 @@ async def test_python_cpp_async_exception():
     assert "c++" in str(ex.value)
 
 
+@pytest.mark.skip("Test is currently segfaulting issue #557")
 @pytest.mark.asyncio
 async def test_can_cancel_coroutine_from_python():
 


### PR DESCRIPTION
## Description
* This created unforeseen downstream problems for Morpheus. Reverting for now, will re-enable later

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
